### PR TITLE
Add coverage range tests

### DIFF
--- a/tests/util/test_date_coverage.py
+++ b/tests/util/test_date_coverage.py
@@ -39,3 +39,20 @@ def test_date_range_coverage_invalid_range():
         assert False, "Should raise ValueError for invalid range"
     except ValueError:
         pass 
+def test_maximal_covered_range_containing_for_covered_date():
+    cov = DateRangeCoverage()
+    cov.mark_covered(date(2024, 1, 1), date(2024, 1, 10))
+    cov.mark_covered(date(2024, 1, 15), date(2024, 1, 20))
+    assert cov.maximal_covered_range_containing(date(2024, 1, 5)) == (
+        date(2024, 1, 1),
+        date(2024, 1, 10),
+    )
+
+
+def test_maximal_covered_range_containing_for_uncovered_date():
+    cov = DateRangeCoverage()
+    cov.mark_covered(date(2024, 1, 1), date(2024, 1, 10))
+    cov.mark_covered(date(2024, 1, 15), date(2024, 1, 20))
+    assert cov.maximal_covered_range_containing(date(2024, 1, 12)) is None
+
+


### PR DESCRIPTION
## Summary
- extend `test_date_coverage` with tests for `maximal_covered_range_containing`

## Testing
- `pytest tests/util/test_date_coverage.py -q -o addopts=""`

------
https://chatgpt.com/codex/tasks/task_e_68434be85310832eb9baa8aefc1a3601