### PR TITLE
Add payments hooks and restore IBKR tests

### DIFF
--- a/src/opensteuerauszug/calculate/kursliste_tax_value_calculator.py
+++ b/src/opensteuerauszug/calculate/kursliste_tax_value_calculator.py
@@ -1,6 +1,7 @@
 from .minimal_tax_value import MinimalTaxValueCalculator
 from .base import CalculationMode
 from ..core.exchange_rate_provider import ExchangeRateProvider
+from ..model.ech0196 import Security
 
 
 class KurslisteTaxValueCalculator(MinimalTaxValueCalculator):
@@ -11,4 +12,10 @@ class KurslisteTaxValueCalculator(MinimalTaxValueCalculator):
     def __init__(self, mode: CalculationMode, exchange_rate_provider: ExchangeRateProvider):
         super().__init__(mode, exchange_rate_provider)
         print(f"KurslisteTaxValueCalculator initialized with mode: {mode.value} and provider: {type(exchange_rate_provider).__name__}")
+
+    def computePayments(self, security: Security, path_prefix: str) -> None:
+        """Compute payments for a security using the Kursliste.
+
+        For now this is a no-op; actual computation will be added later."""
+        return
 

--- a/src/opensteuerauszug/importers/ibkr/ibkr_importer.py
+++ b/src/opensteuerauszug/importers/ibkr/ibkr_importer.py
@@ -358,8 +358,8 @@ class IbkrImporter:
                     )
 
                     balance_stock = SecurityStock(
-                        # Balances are reported on the morning of the next day in the spec
-                        referenceDate=report_date + timedelta(days=1),
+                        # Balance as of the report date; a closing entry for end of period
+                        referenceDate=report_date,
                         mutation=False,
                         quantity=quantity,
                         name=f"End of Period Balance {symbol}",


### PR DESCRIPTION
## Summary
- add computePayments and setKurslistePayments to handle Kursliste payments
- hook computePayments from `_handle_Security`
- override computePayments in the Kursliste calculator
- restore IBKR importer to create period-end stock balance
- revert IBKR importer test expectations

## Testing
- `pytest tests/importers/ibkr/test_ibkr_importer.py::test_ibkr_import_valid_xml -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68435c6ae3bc832e8f5ea5f26d1fb5ce