### PR TITLE
Improve CHF currency formatting

### DIFF
--- a/src/opensteuerauszug/render/render.py
+++ b/src/opensteuerauszug/render/render.py
@@ -86,13 +86,24 @@ def format_currency_2dp(value: Decimal, default='0.00'):
 
 # For most values we use 2 decimals, or leave blank it None or zero
 def format_currency(value: Optional[Decimal], default=''):
-    """Format currency with 2 decimals, for detail tables."""
-    if value is None or value == Decimal(0): return default
+    """Format currency, trimming trailing zeros for better alignment."""
+    if value is None or value == Decimal(0):
+        return default
+
     try:
         decimal_value = round_accounting(value)
-        formatted = '{:,f}'.format(decimal_value).replace(',', "'")
-        return formatted
-    except: return default
+
+        two_dec = decimal_value.quantize(Decimal("0.01"))
+        three_dec = decimal_value.quantize(Decimal("0.001"))
+
+        if two_dec == three_dec:
+            formatted = "{:,.2f}".format(two_dec)
+        else:
+            formatted = "{:,.3f}".format(three_dec)
+
+        return formatted.replace(',', "'")
+    except Exception:
+        return default
 
 # For exchange rates we limit to 4 decimals, don't show if 1
 def format_exchange_rate(value: Decimal, default=''):

--- a/tests/render/test_render.py
+++ b/tests/render/test_render.py
@@ -29,6 +29,7 @@ from opensteuerauszug.render.render import (
     BarcodeDocTemplate,
     create_bank_accounts_table
 )
+import opensteuerauszug.render.render as render
 from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
 from reportlab.platypus import Paragraph, Spacer, SimpleDocTemplate, Table
 from reportlab.lib.enums import TA_LEFT, TA_CENTER, TA_RIGHT
@@ -412,3 +413,12 @@ def test_create_bank_accounts_table_multiple_accounts_with_payments():
     assert "Konto1" in all_text
     assert "Konto2" in all_text
     assert "Zinszahlung" in all_text
+
+
+def test_format_currency_trailing_zero():
+    value_two_dec = Decimal("50.00")
+    value_three_dec = Decimal("50.005")
+
+    assert render.format_currency(value_two_dec) == "50.00"
+    assert render.format_currency(value_three_dec) == "50.005"
+


### PR DESCRIPTION
## Summary
- trim trailing zeros in currency formatting to align decimals
- add tests covering new formatting logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849936a8614832e89f78a87381948b9