### PR TITLE
Set PDF title

### DIFF
--- a/src/opensteuerauszug/render/render.py
+++ b/src/opensteuerauszug/render/render.py
@@ -1259,9 +1259,15 @@ def render_tax_statement(tax_statement: TaxStatement, output_path: Union[str, Pa
     # Compute the organization number
     doc.org_nr = compute_org_nr(tax_statement, override_org_nr)
     doc.company_name = tax_statement.institution.name if tax_statement.institution else ""
-    
+
     # Store tax statement for header access
     doc.tax_statement = tax_statement
+
+    # Set the PDF title using institution name and tax year
+    company_name = tax_statement.institution.name if tax_statement.institution else ""
+    tax_year = str(tax_statement.taxPeriod) if tax_statement.taxPeriod else ""
+    title_parts = ["Steuerauszug", company_name, tax_year]
+    doc.title = " ".join(part for part in title_parts if part)
     
     # Extract and store client information for header display (backward compatibility)
     doc.client_info = extract_client_info(tax_statement)

--- a/tests/render/test_render.py
+++ b/tests/render/test_render.py
@@ -211,6 +211,27 @@ def test_pdf_page_count(mock_render_to_barcodes, sample_tax_statement):
             os.unlink(tmp_path)
 
 @mock.patch('opensteuerauszug.render.render.render_to_barcodes')
+def test_pdf_title_metadata(mock_render_to_barcodes, sample_tax_statement):
+    """Verify that the rendered PDF sets a descriptive title."""
+    mock_render_to_barcodes.return_value = [create_dummy_pil_image()]
+
+    with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
+        tmp_path = tmp.name
+
+    try:
+        render_tax_statement(sample_tax_statement, tmp_path)
+
+        with open(tmp_path, "rb") as f:
+            pdf_reader = pypdf.PdfReader(f)
+            assert (
+                pdf_reader.metadata.title
+                == "Steuerauszug Test Bank AG 2023"
+            )
+    finally:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+
+@mock.patch('opensteuerauszug.render.render.render_to_barcodes')
 def test_barcode_rendering(mock_render_to_barcodes, sample_tax_statement):
     """Test that barcodes are rendered correctly on all pages including a dedicated barcode page."""
     mock_render_to_barcodes.return_value = [create_dummy_pil_image()]


### PR DESCRIPTION
## Summary
- set the PDF title to include institution and tax year only
- verify PDF title via a new unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b539139fc832e9b4672f7d5cd425b