### PR TITLE
Add info page text support

### DIFF
--- a/docs/info_pages.md
+++ b/docs/info_pages.md
@@ -1,0 +1,7 @@
+# Hinweis für die Steuerbehörde
+
+Der vorliegende Steuerauszug wurde automatisch aus Transaktionsdaten generiert. Es handelt sich nicht um ein offizielles Dokument der Bank. Bitte prüfen Sie bei Unklarheiten die Originalunterlagen.
+
+# Important Info & Actions for the tax payer
+
+Diese Datei wurde mit OpenSteuerAuszug erstellt. Die Software ist nicht formell auditiert. Vergleichen Sie alle Werte mit Ihren offiziellen Abrechnungen, bevor Sie die Steuererklärung einreichen.

--- a/src/opensteuerauszug/render/info_loader.py
+++ b/src/opensteuerauszug/render/info_loader.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Optional, List
+
+
+class MarkdownInfo:
+    """Load markdown sections and convert them for ReportLab."""
+
+    def __init__(self, md_path: Path) -> None:
+        self.md_path = md_path
+        self.sections = self._load_sections()
+
+    def _load_sections(self) -> Dict[str, str]:
+        sections: Dict[str, str] = {}
+        if not self.md_path.exists():
+            return sections
+
+        current_title: Optional[str] = None
+        current_lines: List[str] = []
+        with open(self.md_path, "r", encoding="utf-8") as f:
+            for line in f:
+                if line.startswith("#"):
+                    if current_title is not None:
+                        sections[current_title] = "".join(current_lines).strip()
+                    current_title = line.lstrip("#").strip()
+                    current_lines = []
+                else:
+                    current_lines.append(line)
+        if current_title is not None:
+            sections[current_title] = "".join(current_lines).strip()
+        return sections
+
+    def get_html(self, title: str) -> str:
+        return self._markdown_to_html(self.sections.get(title, ""))
+
+    @staticmethod
+    def _markdown_to_html(text: str) -> str:
+        lines = text.strip().splitlines()
+        parts: List[str] = []
+        paragraph: List[str] = []
+        i = 0
+        while i < len(lines):
+            raw = lines[i].rstrip()
+            stripped = raw.strip()
+            if stripped == "":
+                if paragraph:
+                    parts.append(" ".join(paragraph))
+                    paragraph = []
+                i += 1
+                continue
+            if stripped.startswith(('- ', '* ')):
+                if paragraph:
+                    parts.append(" ".join(paragraph))
+                    paragraph = []
+                bullets: List[str] = []
+                while i < len(lines):
+                    bline = lines[i].strip()
+                    if not bline.startswith(('- ', '* ')):
+                        break
+                    bullets.append('\u2022 ' + bline[2:].strip())
+                    i += 1
+                parts.append("<br/>".join(bullets))
+                continue
+            paragraph.append(stripped)
+            i += 1
+        if paragraph:
+            parts.append(" ".join(paragraph))
+        return "<br/><br/>".join(parts)

--- a/src/opensteuerauszug/render/render.py
+++ b/src/opensteuerauszug/render/render.py
@@ -37,9 +37,16 @@ from opensteuerauszug.core.security import determine_security_type, SecurityType
 # --- Import styles utility ---
 from opensteuerauszug.util.styles import get_custom_styles
 from opensteuerauszug.util import round_accounting
+from opensteuerauszug.render.info_loader import MarkdownInfo
 
 # --- Configuration ---
 DOC_INFO = "TODO: Place some compact info here"
+
+# Path to information markdown file
+INFO_MD_PATH = Path(__file__).resolve().parents[3] / "docs" / "info_pages.md"
+
+# Loader for informational markdown sections
+INFO_LOADER = MarkdownInfo(INFO_MD_PATH)
 
 __all__ = [
     'render_tax_statement',
@@ -617,13 +624,16 @@ def create_dual_info_boxes(styles, usable_width):
     """Create two side-by-side information boxes for the first page."""
     val_left = styles['Val_LEFT']
 
+    left_text = INFO_LOADER.get_html('Hinweis für die Steuerbehörde')
+    right_text = INFO_LOADER.get_html('Important Info & Actions for the tax payer')
+
     left_box = Paragraph(
-        '<b>Hinweis für die Steuerbehörde</b><br/><br/>...',
+        f'<b>Hinweis für die Steuerbehörde</b><br/><br/>{left_text}',
         val_left,
     )
 
     right_box = Paragraph(
-        '<b>Important Info & Actions for the tax payer</b><br/><br/>...',
+        f'<b>Important Info & Actions for the tax payer</b><br/><br/>{right_text}',
         val_left,
     )
 
@@ -649,7 +659,8 @@ def create_single_info_page(title, styles):
     """Create simple text content for a dedicated information page."""
     val_left = styles['Val_LEFT']
 
-    return Paragraph(f'<b>{title}</b><br/><br/>...', val_left)
+    body = INFO_LOADER.get_html(title)
+    return Paragraph(f'<b>{title}</b><br/><br/>{body}', val_left)
 
 
 # --- Barcode Generation ---


### PR DESCRIPTION
## Summary
- allow render.py to load information page text from docs/info_pages.md
- display info text in dual boxes and dedicated info pages
- refactor markdown loading into helper class

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685743cedfd4832ea0b42d0ceead16d0