### PR TITLE
Add final XML output option

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,19 @@ from opensteuerauszug import SteuerAuszug
 
 TODO
 
+### Verifying the generated XML
+
+When you export the final XML using `--xml-output`, you can validate it
+against the official eCH-0196 schema with common XML tools.  Examples:
+
+```bash
+# Using libxml2
+xmllint --noout --schema specs/eCH-0196-2-2.xsd output.xml
+
+# Using a Java based validator (Jing)
+java -jar jing.jar specs/eCH-0196-2-2.xsd output.xml
+```
+
 ## Scripts and Tools
 
 This project includes various scripts for data processing, testing, and utility tasks.

--- a/src/opensteuerauszug/steuerauszug.py
+++ b/src/opensteuerauszug/steuerauszug.py
@@ -55,6 +55,7 @@ def main(
     output_file: Path = typer.Option(None, "--output", "-o", help="Output PDF file path."),
     run_phases_input: List[Phase] = typer.Option(None, "--phases", "-p", help="Phases to run (default: all). Specify multiple times or comma-separated."),
     debug_dump_path: Optional[Path] = typer.Option(None, "--debug-dump", help="Directory to dump intermediate model state after each phase (as XML)."),
+    final_xml_path: Optional[Path] = typer.Option(None, "--xml-output", help="Write the final tax statement XML to this file."),
     raw_import: bool = typer.Option(False, "--raw-import", help="Import directly from XML model dump instead of using an importer."),
     importer_type: ImporterType = typer.Option(ImporterType.NONE, "--importer", help="Specify the importer to use."),
     period_from_str: Optional[str] = typer.Option(None, "--period-from", help="Start date of the tax period (YYYY-MM-DD), required for some importers like Schwab."),
@@ -502,6 +503,14 @@ def main(
             # Use the render_tax_statement function to generate the PDF
             rendered_path = render_tax_statement(statement, output_file, override_org_nr=org_nr)
             print(f"Rendering successful to {rendered_path}")
+
+        if final_xml_path:
+            try:
+                statement.to_xml_file(str(final_xml_path))
+                print(f"Final XML written to {final_xml_path}")
+            except Exception as e:
+                print(f"Failed to write final XML to {final_xml_path}: {e}")
+                raise typer.Exit(code=1)
 
         print("Processing finished successfully.")
 

--- a/tests/test_steuerauszug.py
+++ b/tests/test_steuerauszug.py
@@ -150,3 +150,17 @@ def test_main_debug_dump(dummy_input_file: Path, debug_dump_dir: Path):
     assert dump_validate_file.exists()
     # Check content (minimal check for the placeholder JSON dump)
     # assert '"Portfolio"' in dump_import_file.read_text() # Check if it looks like our JSON dump
+
+
+def test_main_final_xml_output(dummy_input_file: Path, tmp_path: Path):
+    """Test writing the final XML with --xml-output."""
+    xml_path = tmp_path / "final.xml"
+    result = runner.invoke(app, [
+        str(dummy_input_file),
+        "--phases", "import",
+        "--phases", "validate",
+        "--xml-output", str(xml_path)
+    ])
+    assert result.exit_code == 0
+    assert "Processing finished successfully." in result.stdout
+    assert xml_path.exists()


### PR DESCRIPTION
## Summary
- allow exporting final XML with `--xml-output`
- test XML output file creation
- document schema verification using xmllint or Jing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cc833bc28832eba08e5769892f99f