### PR TITLE
feat: placeholder front page for minimal tax mode

### DIFF
--- a/src/opensteuerauszug/config/models.py
+++ b/src/opensteuerauszug/config/models.py
@@ -7,6 +7,13 @@ class GeneralSettings(BaseModel):
     full_name: str = Field(description="Your full name for tax documents.")
     language: str = Field(default="de", description="Default language for documents (e.g., 'de', 'fr', 'it').")
     processing_flags: Dict[str, bool] = Field(default_factory=dict, description="Default processing flags.")
+    minimal_uses_placeholder_frontpage: bool = Field(
+        default=True,
+        description=(
+            "If True, a minimal tax statement replaces the summary on the first "
+            "page with a placeholder notice and different info texts."
+        ),
+    )
 
     model_config = ConfigDict(extra="allow")
 

--- a/src/opensteuerauszug/render/templates/tax_office_minimal.de.md
+++ b/src/opensteuerauszug/render/templates/tax_office_minimal.de.md
@@ -1,0 +1,11 @@
+## Hinweis für die Steuerbehörde
+
+{: .short-version }
+
+Dies ist kein offizieller Steuerauszug.
+Dieses Minimaldokument enthält nur die notwendigen Barcodes zur Übernahme der Bankdaten.
+
+{: .long-version }
+
+Dies ist kein offizieller Steuerauszug. Es enthält lediglich Barcodes,
+damit die Bankdaten in die Steuersoftware importiert werden können.

--- a/src/opensteuerauszug/render/templates/tax_payer_minimal.en.md
+++ b/src/opensteuerauszug/render/templates/tax_payer_minimal.en.md
@@ -1,0 +1,9 @@
+## Important Info for the tax payer
+
+{: .short-version }
+
+This is not a real tax statement. It only provides barcodes so that your bank data can be imported.
+
+{: .long-version }
+
+This is not a real tax statement. It only contains barcodes for importing the bank data into the tax software.

--- a/src/opensteuerauszug/steuerauszug.py
+++ b/src/opensteuerauszug/steuerauszug.py
@@ -514,7 +514,19 @@ def main(
                     raise ValueError(f"Invalid --org-nr '{org_nr}': Must be a 5-digit string.")
             
             # Use the render_tax_statement function to generate the PDF
-            rendered_path = render_tax_statement(statement, output_file, override_org_nr=org_nr)
+            rendered_path = render_tax_statement(
+                statement,
+                output_file,
+                override_org_nr=org_nr,
+                minimal_frontpage_placeholder=(
+                    (tax_calculation_level == TaxCalculationLevel.MINIMAL)
+                    and (
+                        general_config_settings.minimal_uses_placeholder_frontpage
+                        if general_config_settings
+                        else True
+                    )
+                ),
+            )
             print(f"Rendering successful to {rendered_path}")
 
         if final_xml_path:

--- a/tests/render/test_render.py
+++ b/tests/render/test_render.py
@@ -211,6 +211,27 @@ def test_pdf_page_count(mock_render_to_barcodes, sample_tax_statement):
         if os.path.exists(tmp_path):
             os.unlink(tmp_path)
 
+
+@mock.patch('opensteuerauszug.render.render.render_to_barcodes')
+def test_render_tax_statement_minimal_placeholder(mock_render_to_barcodes, sample_tax_statement):
+    """Ensure minimal mode renders placeholder instead of summary."""
+    mock_render_to_barcodes.return_value = [create_dummy_pil_image()]
+
+    with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as temp_file:
+        temp_path = temp_file.name
+
+    try:
+        render_tax_statement(sample_tax_statement, temp_path, minimal_frontpage_placeholder=True)
+
+        with open(temp_path, "rb") as f:
+            pdf_reader = pypdf.PdfReader(f)
+            text = pdf_reader.pages[0].extract_text()
+            assert "Minimaldokument" in text
+            assert "1'001" not in text
+    finally:
+        if os.path.exists(temp_path):
+            os.unlink(temp_path)
+
 @mock.patch('opensteuerauszug.render.render.render_to_barcodes')
 def test_pdf_title_metadata(mock_render_to_barcodes, sample_tax_statement):
     """Verify that the rendered PDF sets a descriptive title."""


### PR DESCRIPTION
## Summary
- add `minimal_uses_placeholder_frontpage` config option to control minimal-mode rendering
- simplify `render_tax_statement` to accept a single placeholder flag
- supply minimal-mode templates and tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68905bf85ac8832e8b714d7b6cfc2bdf