### PR TITLE
Ignore Advisor Fees

### DIFF
--- a/src/opensteuerauszug/importers/ibkr/ibkr_importer.py
+++ b/src/opensteuerauszug/importers/ibkr/ibkr_importer.py
@@ -557,7 +557,11 @@ class IbkrImporter:
                             logger.warning(f"Broker interest paid for {description} is not handled for liabilities.")
                             continue
                         elif tx_type in [ibflex.CashAction.FEES]:
-                            # TODO: Optionally create a costs sectioons.
+                            # TODO: Optionally create a costs sections.
+                            logger.warning(f"Fees paid for {description} are ignored for statement.")
+                            continue
+                        elif tx_type in [ibflex.CashAction.ADVISORFEES]:
+                            # TODO: Optionally create a costs sections.
                             logger.warning(f"Fees paid for {description} are ignored for statement.")
                             continue
                         elif tx_type in [ibflex.CashAction.BROKERINTRCVD]:


### PR DESCRIPTION
Cash Actions will list fees paid to the advisor. Ignore them for the time being (copied from CashAction.FEES section above), with a TODO for the Costs section.

While there, fix a typo

Signed-off-by:	Johannes Meixner <xmj@chaot.net>
Sponsored-by:	Meixner GmbH