### PR TITLE
Render withholding tax claim with two decimals on cover page

### DIFF
--- a/src/opensteuerauszug/render/render.py
+++ b/src/opensteuerauszug/render/render.py
@@ -399,7 +399,7 @@ def create_summary_table(data, styles, usable_width):
          Paragraph(format_currency_rounded(summary_data.get('brutto_mit_vst')), val_right),
          '',
          Paragraph(format_currency_rounded(summary_data.get('brutto_ohne_vst')), val_right),
-         Paragraph(format_currency_rounded(summary_data.get('vst_anspruch')), val_right),
+         Paragraph(format_currency_2dp(summary_data.get('vst_anspruch')), val_right),
          '',
          Paragraph(footnote_text, val_left)],
         # Row 2: Spacer row (6 columns)


### PR DESCRIPTION
### Motivation
- The cover-page summary table currently formats the withholding tax claim (`vst_anspruch`) without cents, but the value can include two decimal places and should be shown with cents precision.

### Description
- Changed the summary table rendering in `src/opensteuerauszug/render/render.py` to use `format_currency_2dp` instead of `format_currency_rounded` for the `vst_anspruch` field so the withholding tax claim is displayed with two decimal places.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69734a1bea74832e987f6922c67eaf1d)