### PR TITLE
Make sample discovery repo-root aware and use bundled kursliste in CLI tests

### DIFF
--- a/tests/test_steuerauszug.py
+++ b/tests/test_steuerauszug.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from opensteuerauszug.steuerauszug import app # Updated import
 
 runner = CliRunner()
+KURSLISTE_SAMPLE_DIR = Path(__file__).resolve().parent / "samples" / "kursliste"
 
 @pytest.fixture
 def dummy_input_file(tmp_path: Path) -> Path:
@@ -58,7 +59,16 @@ def test_main_missing_input(tmp_path: Path):
 
 def test_main_basic_run(dummy_input_file: Path):
     """Test a basic run with default phases (will hit placeholders)."""
-    result = runner.invoke(app, [str(dummy_input_file), "--tax-year", "2024"])
+    result = runner.invoke(
+        app,
+        [
+            str(dummy_input_file),
+            "--tax-year",
+            "2024",
+            "--kursliste-dir",
+            str(KURSLISTE_SAMPLE_DIR),
+        ],
+    )
     # It should fail because the output file is missing for the render phase by default
     assert result.exit_code == 1
     assert f"Input file: {dummy_input_file}" in result.stdout
@@ -117,15 +127,25 @@ def test_main_raw_import(dummy_xml_file: Path):
 def test_main_raw_import_with_phases(dummy_xml_file: Path, tmp_path: Path):
     """Test raw import followed by other phases."""
     output_path = tmp_path / "output.pdf"
-    result = runner.invoke(app, [
-        str(dummy_xml_file),
-        "--raw-import",
-        "--tax-year", "2024",
-        "--phases", "validate",
-        "--phases", "calculate",
-        "--phases", "render",
-        "--output", str(output_path)
-    ])
+    result = runner.invoke(
+        app,
+        [
+            str(dummy_xml_file),
+            "--raw-import",
+            "--tax-year",
+            "2024",
+            "--phases",
+            "validate",
+            "--phases",
+            "calculate",
+            "--phases",
+            "render",
+            "--output",
+            str(output_path),
+            "--kursliste-dir",
+            str(KURSLISTE_SAMPLE_DIR),
+        ],
+    )
     # The test will likely fail in render phase due to missing data
     # but we can check that the earlier phases worked
     assert "Raw importing model from" in result.stdout


### PR DESCRIPTION
### Motivation
- Tests that locate sample files were brittle when the process CWD differed from the repository root, causing kursliste-dependent CLI tests to fail. 
- CLI tests exercising the calculate/render phases needed a deterministic kursliste directory to avoid missing-data failures.

### Description
- Add `_find_repo_root` and set `REPO_ROOT` in `tests/utils/samples.py` to locate the repository root by looking for `pyproject.toml` or `.git`. 
- Update `get_sample_files` to resolve `base_dir` relative to `REPO_ROOT` and normalize private/extra sample lookups using `Path` and `glob`. 
- Update `get_sample_dirs` to search `EXTRA_SAMPLE_DIR`, `private/samples`, `tests/samples`, and `data/` under `REPO_ROOT` and return string paths for discovered directories. 
- Point CLI tests to the bundled kursliste samples by adding `KURSLISTE_SAMPLE_DIR` in `tests/test_steuerauszug.py` and passing `--kursliste-dir` to the tests that exercise calculate/render phases.

### Testing
- Ran the full test suite with `pytest`, which initially showed two failing CLI tests before the test updates and then passed after the changes. 
- Final test run result: `457 passed, 5 skipped` (all automated tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977f66c126c832e9e0ee25ee1784bf3)