### PR TITLE
Ibflex unknown attribute ignore

### DIFF
--- a/src/opensteuerauszug/importers/ibkr/ibkr_importer.py
+++ b/src/opensteuerauszug/importers/ibkr/ibkr_importer.py
@@ -30,11 +30,6 @@ IBKR_ASSET_CATEGORY_TO_ECH_SECURITY_CATEGORY: Final[Dict[str, SecurityCategory]]
 import ibflex
 from ibflex.parser import FlexParserError
 
-# Enable tolerance for unknown XML attributes so that new fields added by
-# Interactive Brokers don't break parsing.  This is only available in the
-# forked version of ibflex (vroonhof/ibflex).
-ibflex.enable_unknown_attribute_tolerance()
-
 
 def is_summary_level(entry: Any) -> bool:
     """Return True when an entry is marked with levelOfDetail SUMMARY."""

--- a/src/opensteuerauszug/steuerauszug.py
+++ b/src/opensteuerauszug/steuerauszug.py
@@ -312,6 +312,15 @@ def main(
                 if not all_ibkr_account_settings_models:
                     print("No specific IBKR account settings found/loaded from config. Using empty list for importer settings.")
 
+                # Enable tolerance for unknown XML attributes so that new
+                # fields added by Interactive Brokers don't break parsing.
+                # This is only available in the forked ibflex
+                # (vroonhof/ibflex).  We enable it here (production path)
+                # rather than at module level so that tests remain strict by
+                # default.  See: https://github.com/vroonhof/opensteuerauszug/issues/48
+                import ibflex
+                ibflex.enable_unknown_attribute_tolerance()
+
                 print(f"Initializing IbkrImporter with {len(all_ibkr_account_settings_models)} IBKR account configuration(s) (if any).")
                 ibkr_importer = IbkrImporter(
                     period_from=parsed_period_from,


### PR DESCRIPTION
Enable `ibflex` unknown attribute tolerance in the production driver to prevent parsing failures.

Interactive Brokers frequently adds new fields to Flex XML exports, which previously caused `ibflex` to error. This change ensures robustness by silently ignoring unknown attributes in production, while tests remain strict by default to catch actual schema regressions. This fixes #48.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-2847db27-09a6-451d-8c56-d4d44ed83ae7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2847db27-09a6-451d-8c56-d4d44ed83ae7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

