### PR TITLE
Use max. zlib compression level

### DIFF
--- a/src/opensteuerauszug/render/render.py
+++ b/src/opensteuerauszug/render/render.py
@@ -910,7 +910,7 @@ def render_to_barcodes(tax_statement: TaxStatement) -> list[PILImage.Image]:
     
     # Use the real XML data for proper macro PDF417 generation
     xml = tax_statement.to_xml_bytes()
-    data = zlib.compress(xml)
+    data = zlib.compress(xml, 9)
 
     file_name = tax_statement.id
 


### PR DESCRIPTION
Default is 6. Enforce 9. This saves a few bytes in the barcodes in my tests.