### PR TITLE
IBKR: Improve stock mutations

### DIFF
--- a/src/opensteuerauszug/importers/ibkr/ibkr_importer.py
+++ b/src/opensteuerauszug/importers/ibkr/ibkr_importer.py
@@ -179,11 +179,11 @@ class IbkrImporter:
                     # test for same sign of quantity
                     and (pending.quantity * stock.quantity) > 0
                 ):
-                    pending.quantity += stock.quantity
-                    if pending.quantity > 0:
-                        pending.name = "Buy"
-                    else:
-                        pending.name = "Sell"
+                    total_quantity = pending.quantity + stock.quantity
+                    if pending.unitPrice != stock.unitPrice:
+                        pending.unitPrice = (pending.quantity * pending.unitPrice + stock.quantity * stock.unitPrice) / total_quantity
+
+                    pending.quantity = total_quantity
                 else:
                     if pending:
                         aggregated.append(pending)
@@ -191,6 +191,7 @@ class IbkrImporter:
                         referenceDate=stock.referenceDate,
                         mutation=True,
                         quantity=stock.quantity,
+                        unitPrice=stock.unitPrice,
                         name=stock.name,
                         balanceCurrency=stock.balanceCurrency,
                         quotationType=stock.quotationType,
@@ -414,8 +415,8 @@ class IbkrImporter:
                         referenceDate=trade_date,
                         mutation=True,
                         quantity=quantity,
-                        name=f"{buy_sell} {abs(quantity)} {symbol} "
-                             f"@ {trade_price} {currency}",
+                        unitPrice=trade_price,
+                        name=buy_sell.value,
                         balanceCurrency=currency,
                         quotationType="PIECE"
                     )

--- a/src/opensteuerauszug/render/render.py
+++ b/src/opensteuerauszug/render/render.py
@@ -1422,7 +1422,7 @@ def create_securities_table(tax_statement, styles, usable_width, security_type: 
                         Paragraph(format_stock_quantity(entry.quantity, entry.mutation, stock_quantity_template), val_right),
                         Paragraph(entry.balanceCurrency if entry.unitPrice else '', val_right),
                         # TODO: What should the resolution of unit price be? UK stocks can have fractions of a penny
-                        Paragraph(format_currency(entry.unitPrice) if getattr(entry, 'unitPrice', None) else '', val_right),
+                        Paragraph(format_currency(entry.unitPrice), val_right),
                         Paragraph('', val_left),
                         Paragraph(format_exchange_rate(entry.exchangeRate) if getattr(entry, 'exchangeRate', None) else '', val_right),
                         Paragraph('', val_right),

--- a/tests/importers/ibkr/test_ibkr_importer.py
+++ b/tests/importers/ibkr/test_ibkr_importer.py
@@ -797,8 +797,10 @@ def test_ibkr_trade_aggregation(sample_ibkr_settings):
         # Should aggregate into a single trade entry per security
         assert len(msft_sec.stock) == 2
         assert msft_sec.stock[0].quantity == Decimal("10")
+        assert msft_sec.stock[0].unitPrice == Decimal("280.50")
         assert len(aapl_sec.stock) == 3
         assert aapl_sec.stock[1].quantity == Decimal("-5")
+        assert aapl_sec.stock[1].unitPrice == Decimal("179.70")
     finally:
         if os.path.exists(xml_file_path):
             os.remove(xml_file_path)


### PR DESCRIPTION
- use consistent label for both aggregated and non-aggregated trades
- set `unitPrice` attribute instead of appending trade price into label