### PR TITLE
Fix Issue #197: Prevent TotalCalculator from overwriting spec fields

### DIFF
--- a/src/opensteuerauszug/model/ech0196.py
+++ b/src/opensteuerauszug/model/ech0196.py
@@ -930,6 +930,12 @@ class BankAccount(BaseXmlModel):
     totalGrossRevenueBCanton: Optional[Decimal] = Field(default=None, json_schema_extra={'is_attribute': True})
     totalWithHoldingTaxClaim: Optional[Decimal] = Field(default=None, json_schema_extra={'is_attribute': True}) # required in XSD
 
+    # Internal totals for rendering
+    internalTotalTaxValue: Optional[Decimal] = Field(default=None, exclude=True)
+    internalTotalGrossRevenueA: Optional[Decimal] = Field(default=None, exclude=True)
+    internalTotalGrossRevenueB: Optional[Decimal] = Field(default=None, exclude=True)
+    internalTotalWithHoldingTaxClaim: Optional[Decimal] = Field(default=None, exclude=True)
+
     model_config = {
         "arbitrary_types_allowed": True,
         "json_schema_extra": {'tag_name': 'bankAccount', 'tag_namespace': NS_MAP['eCH-0196']}
@@ -943,6 +949,12 @@ class ListOfBankAccounts(BaseXmlModel):
     totalGrossRevenueA: Optional[Decimal] = Field(default=None, json_schema_extra={'is_attribute': True}) # required in XSD
     totalGrossRevenueB: Optional[Decimal] = Field(default=None, json_schema_extra={'is_attribute': True}) # required in XSD
     totalWithHoldingTaxClaim: Optional[Decimal] = Field(default=None, json_schema_extra={'is_attribute': True}) # required in XSD
+
+    # Internal totals for rendering
+    internalTotalTaxValue: Optional[Decimal] = Field(default=None, exclude=True)
+    internalTotalGrossRevenueA: Optional[Decimal] = Field(default=None, exclude=True)
+    internalTotalGrossRevenueB: Optional[Decimal] = Field(default=None, exclude=True)
+    internalTotalWithHoldingTaxClaim: Optional[Decimal] = Field(default=None, exclude=True)
 
     model_config = {
         "arbitrary_types_allowed": True,
@@ -1011,6 +1023,10 @@ class LiabilityAccount(BaseXmlModel):
         json_schema_extra={'is_attribute': True}
     ) # Required in XSD
     
+    # Internal totals for rendering
+    internalTotalTaxValue: Optional[Decimal] = Field(default=None, exclude=True)
+    internalTotalGrossRevenueB: Optional[Decimal] = Field(default=None, exclude=True)
+
     model_config = {
         "arbitrary_types_allowed": True,
         "json_schema_extra": {'tag_name': 'liabilityAccount', 'tag_namespace': NS_MAP['eCH-0196']}
@@ -1022,6 +1038,10 @@ class ListOfLiabilities(BaseXmlModel):
     # attributes
     totalTaxValue: Optional[PositiveDecimal] = Field(default=None, json_schema_extra={'is_attribute': True}) # positive-decimal, required
     totalGrossRevenueB: Optional[PositiveDecimal] = Field(default=None, json_schema_extra={'is_attribute': True}) # positive-decimal, required
+
+    # Internal totals for rendering
+    internalTotalTaxValue: Optional[Decimal] = Field(default=None, exclude=True)
+    internalTotalGrossRevenueB: Optional[Decimal] = Field(default=None, exclude=True)
 
     model_config = {
         "arbitrary_types_allowed": True,
@@ -1291,6 +1311,17 @@ class ListOfSecurities(BaseXmlModel):
     totalGrossRevenueIUP: Optional[Decimal] = Field(default=None, json_schema_extra={'is_attribute': True}) # required
     totalGrossRevenueConversion: Optional[Decimal] = Field(default=None, json_schema_extra={'is_attribute': True}) # required
 
+    # Internal totals for rendering
+    internalTotalTaxValue: Optional[Decimal] = Field(default=None, exclude=True)
+    internalTotalGrossRevenueA: Optional[Decimal] = Field(default=None, exclude=True)
+    internalTotalGrossRevenueB: Optional[Decimal] = Field(default=None, exclude=True)
+    internalTotalWithHoldingTaxClaim: Optional[Decimal] = Field(default=None, exclude=True)
+    internalTotalLumpSumTaxCredit: Optional[Decimal] = Field(default=None, exclude=True)
+    internalTotalAdditionalWithHoldingTaxUSA: Optional[Decimal] = Field(default=None, exclude=True)
+    internalTotalNonRecoverableTax: Optional[Decimal] = Field(default=None, exclude=True)
+    internalTotalGrossRevenueIUP: Optional[Decimal] = Field(default=None, exclude=True)
+    internalTotalGrossRevenueConversion: Optional[Decimal] = Field(default=None, exclude=True)
+
     model_config = {
         "arbitrary_types_allowed": True,
         "json_schema_extra": {'tag_name': 'listOfSecurities', 'tag_namespace': NS_MAP['eCH-0196']}
@@ -1347,11 +1378,12 @@ class TaxStatement(TaxStatementBase):
     svTaxValueB: Optional[Decimal] = Field(default=None, exclude=True)
     svGrossRevenueA: Optional[Decimal] = Field(default=None, exclude=True)
     svGrossRevenueB: Optional[Decimal] = Field(default=None, exclude=True)
-    da1TaxValue: Optional[Decimal] = Field(default=Decimal('0'), exclude=True)
-    da_GrossRevenue: Optional[Decimal] = Field(default=Decimal('0'), exclude=True)
-    pauschale_da1: Optional[Decimal] = Field(default=Decimal('0'), exclude=True)
-    rueckbehalt_usa: Optional[Decimal] = Field(default=Decimal('0'), exclude=True)
+    da1TaxValue: Optional[Decimal] = Field(default=None, exclude=True)
+    da_GrossRevenue: Optional[Decimal] = Field(default=None, exclude=True)
+    pauschale_da1: Optional[Decimal] = Field(default=None, exclude=True)
+    rueckbehalt_usa: Optional[Decimal] = Field(default=None, exclude=True)
     total_brutto_gesamt: Optional[Decimal] = Field(default=None, exclude=True)
+    internalTotalWithHoldingTaxClaim: Optional[Decimal] = Field(default=None, exclude=True)
     # importer_name: Optional[str] = Field(default=None, exclude=True) # Field removed as per instruction
 
     # Critical warnings collected during import and calculation phases.


### PR DESCRIPTION
Fixes Issue #197 by ensuring that the `TotalCalculator` writes calculated totals to internal fields (e.g., `internalTotalTaxValue`, `internalTotalGrossRevenueA`) rather than overwriting the standard eCH-0196 export fields (`totalTaxValue`, etc.).

Changes:
- Added internal fields to `TaxStatement`, `ListOfSecurities`, `ListOfBankAccounts`, `ListOfLiabilities`, `BankAccount`, and `LiabilityAccount` models in `src/opensteuerauszug/model/ech0196.py`. These fields are marked `exclude=True` to prevent serialization.
- Modified `TotalCalculator` in `src/opensteuerauszug/calculate/total.py` to populate these internal fields during `FILL` and `OVERWRITE` modes. In `VERIFY` mode, it verifies the calculated values against the existing spec fields.
- Updated `src/opensteuerauszug/render/render.py` to use a new helper `get_val_with_fallback` that prioritizes internal fields for display, falling back to spec fields if internal fields are missing (e.g., if calculator wasn't run). This ensures the PDF report shows the calculated values while preserving the original imported values in the data model for export.
- Updated unit tests in `tests/calculate/test_total.py` to verify calculations against internal fields.

This ensures that imported tax statements preserve their original totals in the XML export, while providing accurate recalculated totals for the generated PDF report.

---
*PR created automatically by Jules for task [14800570527800998343](https://jules.google.com/task/14800570527800998343) started by @vroonhof*