### PR TITLE
fix(calculate): downgrade stock split validation errors to warnings

### DIFF
--- a/src/opensteuerauszug/model/critical_warning.py
+++ b/src/opensteuerauszug/model/critical_warning.py
@@ -15,6 +15,7 @@ class CriticalWarningCategory(str, Enum):
     """Category of a critical warning."""
 
     MISSING_KURSLISTE = "missing_kursliste"
+    STOCK_SPLIT_MISMATCH = "stock_split_mismatch"
     UNMAPPED_SYMBOL = "unmapped_symbol"
     PREVIOUS_YEAR_EXDATE = "previous_year_exdate"
     OTHER = "other"


### PR DESCRIPTION
## Summary

- Downgrades stock split validation errors to warnings so that processing can continue when the broker data doesn't contain the exact corporate action mutations expected by the Kursliste.
- Affects both same-ISIN splits (e.g. reverse splits) and cross-ISIN splits (where the valor number changes).
- The user is prompted to verify the affected securities manually in the generated output.

## Context

When processing real IBKR data against the 2025 Kursliste, the calculator crashed on two securities:

1. **NL0015436031** -- a reverse stock split on 2025-10-22 that IBKR did not record as a corporate action in the Flex Query export.
2. **LU1781541179** -- a cross-ISIN split on 2025-02-21 (new valor 131443426) where IBKR's corporate action data didn't match the Kursliste expectation.

These are legitimate discrepancies between the Kursliste and broker data. A hard error prevents the entire Steuerauszug from being generated, which is worse than producing it with a warning for the user to check.

## Changes

All 6 `raise ValueError(...)` calls in `_validate_stock_split` are replaced with `logger.warning(...)` + `return`, covering:
- Missing same-ISIN split mutations
- Same-ISIN split ratio mismatches
- Missing cross-ISIN removal mutations
- Missing new security for cross-ISIN splits
- Missing addition mutations on the new security
- Cross-ISIN addition quantity mismatches
