### PR TITLE
fix: replace Greek delta with ASCII in console output for Windows compatibility

### DIFF
--- a/src/opensteuerauszug/steuerauszug.py
+++ b/src/opensteuerauszug/steuerauszug.py
@@ -563,8 +563,8 @@ def main(
                             f"KL div {row.kursliste_dividend_chf} CHF / KL wht {row.kursliste_withholding_chf} CHF vs "
                             f"Broker div {row.broker_dividend_amount} {row.broker_dividend_currency} / "
                             f"Broker wht {row.broker_withholding_amount} {row.broker_withholding_currency}; "
-                            f"ΔCHF(div={div_diff_chf}, wht={wht_diff_chf}); "
-                            f"ΔORIG(div={div_diff_orig} {row.broker_dividend_currency}, "
+                            f"dCHF(div={div_diff_chf}, wht={wht_diff_chf}); "
+                            f"dORIG(div={div_diff_orig} {row.broker_dividend_currency}, "
                             f"wht={wht_diff_orig} {row.broker_withholding_currency})"
                         )
 


### PR DESCRIPTION
## Summary

- Replaces the Unicode Greek capital letter delta (`U+0394`) with ASCII `d` in the payment reconciliation mismatch console output.
- Fixes a `UnicodeEncodeError` on Windows where the default `cp1252` codepage cannot encode this character.

## Context

On Windows, the payment reconciliation phase crashes when printing mismatch details:

```
UnicodeEncodeError: 'charmap' codec can't encode character '\u0394' in position 140: character maps to <undefined>
```

The `cp1252` codepage used by default on Windows does not include the Greek delta character. Replacing `ΔCHF` / `ΔORIG` with `dCHF` / `dORIG` preserves readability while ensuring cross-platform compatibility.
