### PR TITLE
chore: Unbreak PR sample zip comment

### DIFF
--- a/.github/workflows/pr-generate-sample-output-comment.yml
+++ b/.github/workflows/pr-generate-sample-output-comment.yml
@@ -1,4 +1,4 @@
-name: Comment sample PDF link on PR
+name: Comment sample PDF and XML link on PR
 
 on:
   workflow_run:

--- a/.github/workflows/pr-generate-sample-output.yml
+++ b/.github/workflows/pr-generate-sample-output.yml
@@ -1,4 +1,4 @@
-name: Generate sample PDF for PR
+name: Generate sample PDF and XML for PR
 
 on:
   pull_request:


### PR DESCRIPTION
Artifacts were built, but not commented because of missed workflow rename. Also rename files now, which should not change anything.