### PR TITLE
Omit `security.taxValue` in case of 0 end-of-period position

### DIFF
--- a/src/opensteuerauszug/calculate/cleanup.py
+++ b/src/opensteuerauszug/calculate/cleanup.py
@@ -428,13 +428,15 @@ class CleanupCalculator:
                                     candidate = security.stock[find_index]
                                     if candidate.referenceDate == period_end_plus_one and not candidate.mutation:
                                         # First balance after the period end is the end balance of the period
-                                        security.taxValue = SecurityTaxValue(
-                                            referenceDate=self.period_to,
-                                            quotationType=candidate.quotationType,
-                                            quantity=candidate.quantity,
-                                            balanceCurrency=candidate.balanceCurrency,
-                                            balance=candidate.balance,
-                                            unitPrice=candidate.unitPrice)
+                                        # Only create taxValue if closing balance is not zero
+                                        if candidate.quantity is not None and candidate.quantity != Decimal('0'):
+                                            security.taxValue = SecurityTaxValue(
+                                                referenceDate=self.period_to,
+                                                quotationType=candidate.quotationType,
+                                                quantity=candidate.quantity,
+                                                balanceCurrency=candidate.balanceCurrency,
+                                                balance=candidate.balance,
+                                                unitPrice=candidate.unitPrice)
 
                             # TODO Should we ensure the balances at the start and end of the period are
                             #       present here instead of in the importers?.

--- a/src/opensteuerauszug/importers/schwab/schwab_importer.py
+++ b/src/opensteuerauszug/importers/schwab/schwab_importer.py
@@ -553,12 +553,14 @@ def convert_cash_positions_to_list_of_bank_accounts(
                     break
         
         if closing_stock_entry:
-            bank_account.taxValue = BankAccountTaxValue(
-                referenceDate=period_to, # Tax value is as of end of period_to
-                name="Closing Balance",
-                balanceCurrency=closing_stock_entry.balanceCurrency,
-                balance=closing_stock_entry.quantity # Quantity of cash is its balance
-            )
+            # Only create taxValue if closing balance is not zero
+            if closing_stock_entry.quantity is not None and closing_stock_entry.quantity != Decimal('0'):
+                bank_account.taxValue = BankAccountTaxValue(
+                    referenceDate=period_to, # Tax value is as of end of period_to
+                    name="Closing Balance",
+                    balanceCurrency=closing_stock_entry.balanceCurrency,
+                    balance=closing_stock_entry.quantity # Quantity of cash is its balance
+                )
         accounts.append(bank_account)
     return ListOfBankAccounts(bankAccount=accounts)
 


### PR DESCRIPTION
From the specs, p.32:
> Nur wenn der Endbestand eines Titels zum Periodenende (periodTo) grösser als 0 ist, dann ist der Steuerwert anzugeben.