### PR TITLE
IBKR: Do not set trade price if 0

### DIFF
--- a/src/opensteuerauszug/importers/ibkr/ibkr_importer.py
+++ b/src/opensteuerauszug/importers/ibkr/ibkr_importer.py
@@ -417,7 +417,7 @@ class IbkrImporter:
                         referenceDate=trade_date,
                         mutation=True,
                         quantity=quantity,
-                        unitPrice=trade_price,
+                        unitPrice=trade_price if trade_price != Decimal(0) else None,
                         name=buy_sell.value,
                         orderId=trade.ibOrderID,
                         balanceCurrency=currency,


### PR DESCRIPTION
Official validation tool does not allow 0 value unit price (failing check: SECURITY-04-11 - Stückpreis angegeben). Since this is an optional attribute, omit it.

Such 0 values trades can be found in the example XML of issue #218.