### PR TITLE
chore: Reduce size of rendered preview images

### DIFF
--- a/.github/workflows/update-sample-previews.yml
+++ b/.github/workflows/update-sample-previews.yml
@@ -52,10 +52,10 @@ jobs:
       - name: Extract page 1 (Summary) and page 3 (Stock table) as PNG
         run: |
           # Page 1 – Summary page (pdftoppm pages are 1-indexed)
-          pdftoppm -r 150 -png -f 1 -l 1 -singlefile \
+          pdftoppm -r 60 -png -f 1 -l 1 -singlefile \
             docs/sample_output.pdf docs/sample_summary_page
           # Page 3 – Stock table example
-          pdftoppm -r 150 -png -f 3 -l 3 -singlefile \
+          pdftoppm -r 60 -png -f 3 -l 3 -singlefile \
             docs/sample_output.pdf docs/sample_stock_table_page
 
       - name: Commit updated previews


### PR DESCRIPTION
This prevents blowing up the repo quite a bit, and is still large enough to show the idea.