### PR TITLE
Handle broker-side KEP/return-of-capital hints in payment reconciliation

### DIFF
--- a/tests/calculate/test_payment_reconciliation_calculator.py
+++ b/tests/calculate/test_payment_reconciliation_calculator.py
@@ -357,6 +357,73 @@ def test_broker_above_kursliste_with_allowlisted_sign_is_match():
     assert row.status == "match"
 
 
+def test_broker_above_kursliste_with_allowlisted_broker_keyword_is_match():
+    statement = TaxStatement(
+        minorVersion=2,
+        listOfSecurities=ListOfSecurities(
+            depot=[
+                Depot(
+                    depotNumber=DepotNumber("D1"),
+                    security=[
+                        Security(
+                            positionId=1,
+                            country="CH",
+                            currency="CHF",
+                            quotationType="PIECE",
+                            securityCategory="FUND",
+                            securityName="CHSPI",
+                            payment=[
+                                SecurityPayment(
+                                    paymentDate=date(2025, 7, 17),
+                                    quotationType="PIECE",
+                                    quantity=Decimal("100"),
+                                    amountCurrency="CHF",
+                                    amount=Decimal("44"),
+                                    exchangeRate=Decimal("1"),
+                                    grossRevenueA=Decimal("44"),
+                                    withHoldingTaxClaim=Decimal("15.40"),
+                                    kursliste=True,
+                                )
+                            ],
+                            broker_payments=[
+                                SecurityPayment(
+                                    paymentDate=date(2025, 7, 17),
+                                    quotationType="PIECE",
+                                    quantity=Decimal("-100"),
+                                    amountCurrency="CHF",
+                                    amount=Decimal("44"),
+                                    name="Ordinary Dividend",
+                                ),
+                                SecurityPayment(
+                                    paymentDate=date(2025, 7, 17),
+                                    quotationType="PIECE",
+                                    quantity=Decimal("-100"),
+                                    amountCurrency="CHF",
+                                    amount=Decimal("40"),
+                                    name="Return of Capital",
+                                ),
+                                SecurityPayment(
+                                    paymentDate=date(2025, 7, 17),
+                                    quotationType="PIECE",
+                                    quantity=Decimal("-100"),
+                                    amountCurrency="CHF",
+                                    amount=Decimal("-15.40"),
+                                    name="Withholding",
+                                    nonRecoverableTaxAmountOriginal=Decimal("15.40"),
+                                ),
+                            ],
+                        )
+                    ],
+                )
+            ]
+        ),
+    )
+
+    result = PaymentReconciliationCalculator().calculate(statement)
+    row = result.payment_reconciliation_report.rows[0]
+    assert row.status == "match"
+
+
 def test_negligible_kursliste_values_allow_missing_broker_entry():
     statement = TaxStatement(
         minorVersion=2,


### PR DESCRIPTION
### Motivation
- Reconciliation reported false mismatches when a broker emitted both a taxable dividend and a tax-free return-of-capital on the same date but the Kursliste only contained the taxable amount (KEP-like cases). 

### Description
- Add an `allows_broker_above_kursliste` flag to the per-day broker aggregation (`_BrokerAgg`) to carry allowlist hints originating from broker payment metadata. 
- Detect broker-side allowlist signals by checking broker payment `sign`, `name`, and `broker_label_original` for known allowlist signs/keywords and set the broker-day flag accordingly. 
- Combine the Kursliste-side and broker-side allowlist flags when computing `allow_broker_above_kursliste` and pass that into the component-matching logic so broker totals may legitimately exceed Kursliste totals for those days. 
- Add a regression unit test reproducing the CHSPI scenario (taxable ordinary dividend + broker-only return-of-capital + matching withholding) asserting reconciliation now reports `match`.

### Testing
- Ran the reconciliation unit tests with `pytest -q tests/calculate/test_payment_reconciliation_calculator.py` and all tests passed (`9 passed`).
- The new regression test `test_broker_above_kursliste_with_allowlisted_broker_keyword_is_match` verifies the reported scenario and passes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c406b3fac832e8ecc20d1ebbcc32c)