### PR TITLE
Set `undefined` attribute for `security.taxValue`

### DIFF
--- a/src/opensteuerauszug/calculate/kursliste_tax_value_calculator.py
+++ b/src/opensteuerauszug/calculate/kursliste_tax_value_calculator.py
@@ -214,6 +214,8 @@ class KurslisteTaxValueCalculator(MinimalTaxValueCalculator):
                     self._set_field_value(sec_tax_value, "balanceCurrency", "CHF", path_prefix)
                     self._set_field_value(sec_tax_value, "kursliste", True, path_prefix)
                     return
+        else:
+            self._set_field_value(sec_tax_value, "undefined", True, path_prefix)
 
         super()._handle_SecurityTaxValue(sec_tax_value, path_prefix)
 

--- a/src/opensteuerauszug/calculate/minimal_tax_value.py
+++ b/src/opensteuerauszug/calculate/minimal_tax_value.py
@@ -247,6 +247,8 @@ class MinimalTaxValueCalculator(BaseCalculator):
             # If there's a value but no currency, this is an error as we cannot process it.
             raise ValueError(f"SecurityTaxValue at {path_prefix} has a 'value' but no 'balanceCurrency'. Cannot perform currency conversion or set exchange rate accurately.")
 
+        self._set_field_value(sec_tax_value, "undefined", True, path_prefix)
+
     def _handle_SecurityPayment(self, sec_payment: SecurityPayment, path_prefix: str) -> None:
         """Handles SecurityPayment objects for currency conversion and revenue categorization."""
         # In the base implementation all payments will have been cleared (outside of debugging and verify mode)

--- a/src/opensteuerauszug/render/render.py
+++ b/src/opensteuerauszug/render/render.py
@@ -1703,12 +1703,18 @@ def create_securities_table(tax_statement, styles, usable_width, security_type: 
                 date_str = tax_value.referenceDate.strftime("%d.%m.%Y")
             else:
                 date_str = ""
+
+            unit_price = ''
+            if tax_value and getattr(tax_value, 'unitPrice', None):
+                unit_price = format_currency(tax_value.unitPrice)
+            elif tax_value and getattr(tax_value, 'undefined', None):
+                unit_price = "n.v."
             table_data.append([
                 Paragraph(date_str, bold_left),
                 Paragraph('Bestand / Steuerwert / Ertrag', bold_left),
                 Paragraph(format_stock_quantity(tax_value.quantity, False, stock_quantity_template) if tax_value else '0', val_right),
                 Paragraph(tax_value.balanceCurrency or '' if tax_value else '', val_right),
-                Paragraph(format_currency(tax_value.unitPrice) if tax_value and getattr(tax_value, 'unitPrice', None) else '', val_right),
+                Paragraph(unit_price, val_right),
                 Paragraph('', val_left),
                 Paragraph('', val_right),
                 Paragraph(format_currency_2dp(tax_value.value) if tax_value and getattr(tax_value, 'value', None) else '', bold_right),

--- a/tests/calculate/test_minimal_tax_value.py
+++ b/tests/calculate/test_minimal_tax_value.py
@@ -288,6 +288,7 @@ class TestMinimalTaxValueCalculatorHandlers:
         calculator._handle_SecurityTaxValue(stv, "stv")
         assert stv.exchangeRate == Decimal("0.5")
         assert stv.value is None # Value remains None
+        assert stv.undefined is True # undefined field is set
 
     def test_handle_security_payment_no_op(self, minimal_tax_value_calculator_fill: MinimalTaxValueCalculator):
         calculator = minimal_tax_value_calculator_fill


### PR DESCRIPTION
- in case of missing (kursliste) value (`unitPrice`), set `undefined` flag as required by spec
- in case `undefined` flag is set to true, render it as `n.v.` (as official renderer)