### PR TITLE
Align PDF417 barcode with spec (re-apply part 1: file id)

### DIFF
--- a/src/opensteuerauszug/render/render.py
+++ b/src/opensteuerauszug/render/render.py
@@ -1235,13 +1235,13 @@ def render_to_barcodes(tax_statement: TaxStatement) -> list[PILImage.Image]:
     # right
     # Overhead:
     #    1  start word
-    #    1 + 2 + 1 macro pdf fields with 1 word file ID
+    #    1 + 2 + 4 macro pdf fields with 4 word file ID
     #    4 for segment count
     #    1 for possible last code marker
     #    32 error correction at level 4
     #    1 for specifying byte encoding
-    # gives 43 words of overhead
-    FIXED_OVERHEAD = 43
+    # gives 46 words of overhead
+    FIXED_OVERHEAD = 46
     # Given in the guidance
     NUM_COLUMNS = 13
     NUM_ROWS = 35
@@ -1252,11 +1252,16 @@ def render_to_barcodes(tax_statement: TaxStatement) -> list[PILImage.Image]:
     capacity = NUM_COLUMNS * NUM_ROWS - FIXED_OVERHEAD - file_name_length
     # Byte encoding efficiency is 6 bytes per 5 codewords
     SEGMENT_SIZE = floor((capacity / 5) * 6)
+    # Official PDF generator uses 4 * 3 digit (<= 255 each) for file ID
+    # Create file ID based on hash of taxstatement id and creation date
+    hash_input = f"{file_name}_{tax_statement.creationDate.timestamp() if tax_statement.creationDate else ''}"
+    digest = hashlib.sha256(hash_input.encode('utf-8')).digest()
+    file_id = [100 + (b % 156) for b in digest[:4]]
 
     # Use encode_macro for proper macro PDF417 generation
     codes = encode_macro(
         data,
-        file_id=[1],
+        file_id=file_id,
         columns=NUM_COLUMNS,
         force_rows=NUM_ROWS,
         security_level=4,


### PR DESCRIPTION
"Beilage zu eCH-0196 V2.2.0 – Barcode Generierung – Technische Wegleitung": "Zur eindeutigen Identifikation beim Scannen sind in den Metadaten im Attribut PDFMacroFileName die ID (siehe Kapitel 2.1) und im Attribut PDFMacroFileId eine zufällige Zahl (4 Integer) abgelegt."

File name will be applied in a follow up change.

Related to #240