### PR TITLE
feat(schwab): support Sell and Stock Plan Activity actions

### DIFF
--- a/src/opensteuerauszug/importers/schwab/transaction_extractor.py
+++ b/src/opensteuerauszug/importers/schwab/transaction_extractor.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 # Known actions from formats.md
 KNOWN_ACTIONS = {
     "Buy", "Cash In Lieu", "Credit Interest", "Deposit", "Dividend", "Journal",
-    "NRA Tax Adj", "Reinvest Dividend", "Reinvest Shares", "Sale", "Stock Split",
+    "NRA Tax Adj", "Reinvest Dividend", "Reinvest Shares", "Sale", "Sell", "Stock Plan Activity", "Stock Split",
     "Tax Withholding", "Transfer", "Wire Transfer"
 }
 
@@ -295,10 +295,10 @@ class TransactionExtractor:
                 if cash_flow:
                      cash_stock = create_cash_stock(cash_flow, f"Cash out for {action} {pos_object.symbol}")
 
-        elif action == "Sale":
+        elif action == "Sale" or action == "Sell":
              if schwab_qty and isinstance(pos_object, SecurityPosition):
                 if schwab_qty < 0:
-                    raise ValueError(f"Invalid negative quantity ({schwab_qty}) for 'Sale' action for symbol {pos_object.symbol}. Sales should have positive quantities representing shares sold.")
+                    raise ValueError(f"Invalid negative quantity ({schwab_qty}) for '{action}' action for symbol {pos_object.symbol}. Sales should have positive quantities representing shares sold.")
                 
                 # Quantity should be negative for a sale in our system
                 final_qty = -schwab_qty 
@@ -319,10 +319,20 @@ class TransactionExtractor:
                 sec_stock = SecurityStock(
                     referenceDate=tx_date, mutation=True, quotationType="PIECE",
                     quantity=final_qty, balanceCurrency=currency, # Use currency string
-                    unitPrice=schwab_price, name="Sale",
+                    unitPrice=schwab_price, name=action,
                 )
                 if cash_flow:
-                     cash_stock = create_cash_stock(cash_flow, f"Cash in for Sale {pos_object.symbol}")
+                     cash_stock = create_cash_stock(cash_flow, f"Cash in for {action} {pos_object.symbol}")
+
+        elif action == "Stock Plan Activity":
+            if schwab_qty and schwab_qty > 0 and isinstance(pos_object, SecurityPosition):
+                sec_stock = SecurityStock(
+                    referenceDate=tx_date, mutation=True, quotationType="PIECE",
+                    quantity=schwab_qty, balanceCurrency=currency, # Use currency string
+                    unitPrice=None, name=action,
+                )
+                # Stock Plan Activity usually has no direct cash flow in the brokerage account (it's the vesting)
+                # Any cash flow (taxes) is usually handled by separate Journal or Tax Withholding entries.
 
         elif action == "Credit Interest":
             # Generates a Payment for the cash account AND a cash stock mutation

--- a/tests/importers/schwab/test_transaction_extractor.py
+++ b/tests/importers/schwab/test_transaction_extractor.py
@@ -896,3 +896,65 @@ class TestSchwabTransactionExtractor:
         assert found_msft_dividend_payment, "MSFT Dividend payment not found or not correctly processed"
         assert found_voo_reinvest_dividend_payment, "VOO Reinvest Dividend payment not found or not correctly processed"
         assert found_zeroq_dividend_payment, "ZEROQ Dividend payment not found or not correctly processed"
+
+    def test_action_sell(self):
+        extractor = create_extractor()
+        data = {
+            "FromDate": "01/01/2024",
+            "ToDate": "12/31/2024",
+            "BrokerageTransactions": [{
+                "Date": "12/30/2024 as of 12/29/2024",
+                "Action": "Sell",
+                "Symbol": "MSFT",
+                "Description": "MICROSOFT CORP",
+                "Quantity": "5.678",
+                "Price": "150.00",
+                "Amount": "851.70"
+            }]
+        }
+        result = extractor._extract_transactions_from_dict(data)
+        assert result is not None
+        
+        msft_data = find_position(result, SecurityPosition, "MSFT")
+        cash_data = find_position(result, CashPosition)
+        
+        assert msft_data is not None
+        pos, stocks, payments = msft_data
+        assert len(stocks) == 1
+        stock = stocks[0]
+        assert stock.quantity == -Decimal("5.678")
+        assert stock.unitPrice == Decimal("150.00")
+        assert stock.name == "Sell"
+        
+        assert cash_data is not None
+        c_pos, c_stocks, c_payments = cash_data
+        assert len(c_stocks) == 1
+        assert c_stocks[0].quantity == Decimal("851.70")
+        assert c_stocks[0].name == "Cash in for Sell MSFT"
+
+    def test_action_stock_plan_activity(self):
+        extractor = create_extractor()
+        data = {
+            "FromDate": "01/01/2024",
+            "ToDate": "12/31/2024",
+            "BrokerageTransactions": [{
+                "Date": "12/30/2024",
+                "Action": "Stock Plan Activity",
+                "Symbol": "MSFT",
+                "Description": "MICROSOFT CORP",
+                "Quantity": "15.0",
+                "Price": "",
+                "Amount": ""
+            }]
+        }
+        result = extractor._extract_transactions_from_dict(data)
+        assert result is not None
+        
+        msft_data = find_position(result, SecurityPosition, "MSFT")
+        assert msft_data is not None
+        pos, stocks, payments = msft_data
+        assert len(stocks) == 1
+        stock = stocks[0]
+        assert stock.quantity == Decimal("15.0")
+        assert stock.unitPrice is None
+        assert stock.name == "Stock Plan Activity"


### PR DESCRIPTION
Added support for 'Sell' and 'Stock Plan Activity' transactions in the Schwab importer.
- 'Sell' is handled as a synonym for 'Sale'.
- 'Stock Plan Activity' is handled as a share acquisition (e.g. vesting) with zero cash flow.
- Added comprehensive unit tests with synthetic data to verify these actions.

Context: These actions are common for users enrolled in employee trading plans (e.g., Google Employee Trading Plan), where vestings appear as 'Stock Plan Activity' and subsequent divestments use the 'Sell' action.

Verified by running pytest on TransactionExtractor: 31 tests passed.