### PR TITLE
chore: Extract translations from render.py

### DIFF
--- a/src/opensteuerauszug/config/models.py
+++ b/src/opensteuerauszug/config/models.py
@@ -1,11 +1,13 @@
 from typing import Dict, Any, Union, Literal, Optional
 from pydantic import BaseModel, Field, ConfigDict
 
+from opensteuerauszug.render.translations import DEFAULT_LANGUAGE
+
 class GeneralSettings(BaseModel):
     '''General settings applicable globally.'''
     canton: Optional[str] = Field(default=None, description="Your canton (e.g., 'ZH', 'BE'). If not provided, will be extracted from importer data (e.g., IBKR flex report).")
     full_name: str = Field(description="Your full name for tax documents.")
-    language: str = Field(default="de", description="Default language for documents (e.g., 'de', 'fr', 'it').")
+    language: str = Field(default=DEFAULT_LANGUAGE, description="Default language for documents (e.g., 'de', 'fr', 'it').")
     processing_flags: Dict[str, bool] = Field(default_factory=dict, description="Default processing flags.")
     minimal_uses_placeholder_frontpage: bool = Field(
         default=True,

--- a/src/opensteuerauszug/render/render.py
+++ b/src/opensteuerauszug/render/render.py
@@ -42,8 +42,16 @@ from opensteuerauszug.core.security import determine_security_type, SecurityType
 from opensteuerauszug.util.styles import get_custom_styles, FONT_REGULAR, FONT_BOLD
 from opensteuerauszug.util import round_accounting
 from opensteuerauszug.render.markdown_renderer import markdown_to_platypus
+from opensteuerauszug.render.translations import t as _t, DEFAULT_LANGUAGE
 
 logger = logging.getLogger(__name__)
+
+# Module-level language context for translations
+_current_language = DEFAULT_LANGUAGE
+
+def t(key: str) -> str:
+    """Translation function that uses the current module-level language context."""
+    return _t(key, _current_language)
 
 __all__ = [
     'render_tax_statement',
@@ -176,7 +184,7 @@ def extract_client_info(tax_statement: TaxStatement) -> Dict[str, str]:
             # Prepare client name with salutation
             salutation = ""
             if hasattr(client, 'salutation') and client.salutation:
-                salutation_codes = {"1": "", "2": "Herr", "3": "Frau"}
+                salutation_codes = {"1": "", "2": t('male'), "3": t('female')}
                 salutation = salutation_codes.get(client.salutation, "")
             
             name_parts = []
@@ -250,23 +258,23 @@ def create_client_info_table(tax_statement: TaxStatement, styles, box_width: flo
     # Handle multiple clients - create separate lines for each
     if 'names' in client_info:
         for name in client_info['names']:
-            table_data.append([Paragraph("Kunde", info_style),
+            table_data.append([Paragraph(t('client'), info_style),
                                Paragraph(escape_html_for_paragraph(name), info_style)])
     
     if 'portfolio' in client_info:
-        table_data.append([Paragraph("Kdnr.", info_style),
+        table_data.append([Paragraph(t('client_number'), info_style),
                            Paragraph(escape_html_for_paragraph(client_info['portfolio']), info_style)])
 
     if 'period' in client_info:
-        table_data.append([Paragraph("Periode", info_style),
+        table_data.append([Paragraph(t('period'), info_style),
                            Paragraph(f"<b>{escape_html_for_paragraph(client_info['period'])}</b>", info_style)])
     
     if 'created' in client_info:
-        table_data.append([Paragraph("Daten von", info_style),
+        table_data.append([Paragraph(t('data_from'), info_style),
                            Paragraph(escape_html_for_paragraph(client_info['created']), info_style)])
 
     if 'canton' in client_info:
-        table_data.append([Paragraph("Kanton", info_style),
+        table_data.append([Paragraph(t('canton'), info_style),
                            Paragraph(escape_html_for_paragraph(client_info['canton']), info_style)])
 
     if not table_data:
@@ -322,7 +330,7 @@ def draw_page_header(canvas, doc, is_barcode_page: bool = False):
         # "erstellt mit" line
         created_with_style = styles['HeaderCreatedWith']
         canvas.setFont(created_with_style.fontName, created_with_style.fontSize)
-        canvas.drawString(doc.leftMargin, page_height - 26*mm, "erstellt mit OpenSteuerauszug")
+        canvas.drawString(doc.leftMargin, page_height - 26*mm, t('created_with'))
 
         # Tax statement title aligned with bottom of client info box - now big and bold
         period_end_date = doc.tax_statement.periodTo.strftime("%d.%m.%Y") if doc.tax_statement.periodTo else "31.12"
@@ -330,8 +338,8 @@ def draw_page_header(canvas, doc, is_barcode_page: bool = False):
         title_style = styles['HeaderTitle']
         canvas.setFont(title_style.fontName, title_style.fontSize)
         canvas.drawString(doc.leftMargin, page_height - doc.topMargin + 3*mm,
-                         f"Steuerauszug in CHF {period_end_date}")
-    
+                         f"{t('tax_statement_in_chf')} {period_end_date}")
+
     # Draw client information table on all pages
     if hasattr(doc, 'tax_statement') and doc.tax_statement:
         box_width = getattr(doc, 'summary_table_last_col_width', 60*mm)  # Default fallback
@@ -409,13 +417,13 @@ def draw_page_footer(canvas, doc):
                 footer_parts.append(uid_text)
 
     if footer_parts:
-        footer_text = ", ".join(footer_parts) + " konvertiert mit OpenSteuerauszug (https://github.com/vroonhof/opensteuerauszug)"
+        footer_text = ", ".join(footer_parts) + f" {t('converted_with')} (https://github.com/vroonhof/opensteuerauszug)"
         canvas.drawString(doc.leftMargin, footer_y, footer_text)
 
     # Page Number - Standard onPageEnd handlers typically only get current page number
     if not getattr(canvas, "defer_page_number", False):
         page_num = canvas.getPageNumber()
-        text = f"Seite {page_num}"
+        text = f"{t('page').format(page=page_num, total=0)}" # total will be filled in by NumberedCanvas
         canvas.drawRightString(page_width - doc.rightMargin, footer_y, text)
     canvas.restoreState()
 
@@ -445,7 +453,7 @@ class NumberedCanvas(canvas.Canvas):
 
     def _draw_page_number(self, page_count: int) -> None:
         page_num = self.getPageNumber()
-        text = f"Seite {page_num} von {page_count}"
+        text = f"{t('page').format(page=page_num, total=page_count)}"
         self.setFont(FONT_REGULAR, 8)
         footer_y = self.bottom_margin - 10 * mm
         page_width = self._pagesize[0]
@@ -467,7 +475,7 @@ def create_summary_table(data, styles, usable_width):
     bold_right = styles['Bold_RIGHT']
 
     # Footnote
-    footnote_text = "(1) Davon <b>A</b> {} und <b>B</b> {}".format(
+    footnote_text = t('footnote_ab_breakdown').format(
         format_currency_rounded(summary_data.get('steuerwert_a', '')),
         format_currency_rounded(summary_data.get('steuerwert_b', ''))
     )
@@ -475,19 +483,18 @@ def create_summary_table(data, styles, usable_width):
     # --- Data structure based on 6 columns, with Totals shifted ---
     table_data = [
         # Row 0: A/B Headers (Indices 2 & 5 blank)
-        [Paragraph(f'<b>Steuerwert</b> der<br/><b>A</b>- und <b>B</b>-Werte am {summary_data.get("period_end_date", "31.12")}', header_style),
+        [Paragraph(t('tax_value_ab_header').format(date=summary_data.get("period_end_date", "31.12")), header_style),
          '',
-         Paragraph('<b>A</b>', val_center), # 'A' in its own column (index 2)
-         Paragraph(f'<b>Bruttoertrag</b><br/>{summary_data.get("tax_period", "")} Werte <b>mit</b> VSt.-Abzug', header_style),
+         Paragraph(f'<b>{t("column_a")}</b>', val_center), # 'A' in its own column (index 2)
+         Paragraph(t('gross_revenue_values_with_vst').format(period=summary_data.get("tax_period", "")), header_style),
          '',
-         Paragraph('<b>B</b>', val_center), # 'B' in its own column (index 4)
-         Paragraph(f'<b>Bruttoertrag</b><br/>{summary_data.get("tax_period", "")} Werte <b>ohne</b> VSt.-Abzug', header_style),
+         Paragraph(f'<b>{t("column_b")}</b>', val_center), # 'B' in its own column (index 4)
+         Paragraph(t('gross_revenue_values_without_vst').format(period=summary_data.get("tax_period", "")), header_style),
          '',
-         Paragraph('Verrechnungs- steueranspruch', header_style),
+         Paragraph(t('withholding_tax_claim'), header_style),
          '',
          '',
-         Paragraph(f'''Werte für Formular <b>"Wertschriften- und Guthabenverzeichnis"</b>
-(inkl. Konti, ohne Werte DA-1 und USA)''', val_left)],
+         Paragraph(t('instruction_securities_register'), val_left)],
         # Row 1: A/B Values (Index 2 is 'B', Index 5 blank)
         [Paragraph(format_currency_rounded(summary_data.get('steuerwert_ab')), bold_right),
          Paragraph("<super rise=9 size=6>(1)</super>", val_left),
@@ -504,20 +511,18 @@ def create_summary_table(data, styles, usable_width):
         # Row 2: Spacer
         [''],
          # Row 3: DA-1 Headers (Indices 1 & 2 blank)
-        [Paragraph(f'<b>Steuerwert</b> der <b>DA-1</b> und <b>USA</b>- Werte am {summary_data.get("period_end_date", "31.12")}', header_style),
+        [Paragraph(t('tax_value_da1_usa_header').format(date=summary_data.get("period_end_date", "31.12")), header_style),
          '',
          '',
          '',
          '',
          '',
-         Paragraph(f'<b>Bruttoertrag</b> {summary_data.get("tax_period", "")}<br/><b>DA-1</b> und <b>USA</b>-Werte', header_style), # Starts in Col 4
+         Paragraph(t('gross_revenue_da1_usa_header').format(period=summary_data.get("tax_period", "")), header_style), # Starts in Col 4
          '',
-         Paragraph('<b>Anrechnung ausländischer Quellensteuer</b>', header_style),
+         Paragraph(f'<b>{t("foreign_tax_credit_header")}</b>', header_style),
          '',
-         Paragraph('<b>Steuerrückbehalt USA</b>', header_style),
-         Paragraph('''Werte für zusätzliches Formular <b>"DA-1 Antrag auf Anrechnung
-ausländischer Quellensteuer und zusätzlichen Steuerrückbehalt
-USA"</b> (DA-1)''', val_left)], #
+         Paragraph(f'<b>{t("withholding_usa")}</b>', header_style),
+         Paragraph(t('instruction_da1_form'), val_left)], #
          # Row 4: DA-1 Values (Indices 1 & 2 blank)
         [Paragraph(format_currency_rounded(summary_data.get('steuerwert_da1_usa')), bold_right),
          # Paragraph("<super rise=9 size=6>(2)</super>", val_left), # TODO
@@ -538,20 +543,18 @@ USA"</b> (DA-1)''', val_left)], #
         # Row 5: Spacer
         [''],
         # Row 6: Total Headers (** SHIFTED RIGHT **, Indices 1, 2, 5 blank)
-        [Paragraph(f'<b>Total Steuerwert</b> der <b>A, B, DA-1</b> und <b>USA</b>-Werte am {summary_data.get("period_end_date", "31.12")}', header_style), # Col 0
+        [Paragraph(t('total_tax_value_header').format(date=summary_data.get("period_end_date", "31.12")), header_style), # Col 0
          '',
          '',
-         Paragraph(f'<b>Total Bruttoertrag</b> {summary_data.get("tax_period", "")} <b>A</b>-Werte <b>mit</b><br/>VSt.-Abzug', header_style), # Col 3 << SHIFTED
+         Paragraph(t('total_gross_revenue_a_with_vst').format(period=summary_data.get("tax_period", "")), header_style), # Col 3 << SHIFTED
          '',
          '',
-         Paragraph(f'<b>Total Bruttoertrag</b> {summary_data.get("tax_period", "")} <b>B, DA-1</b> und <b>USA</b>-Werte <b>ohne</b> VSt.-Abzug', header_style), # Col 4 << SHIFTED
+         Paragraph(t('total_gross_revenue_b_da1_usa_without_vst').format(period=summary_data.get("tax_period", "")), header_style), # Col 4 << SHIFTED
          '',
-         Paragraph(f'<b>Total Bruttoertrag</b> {summary_data.get("tax_period", "")} <b>A, B, DA-1</b> und <b>USA</b>-Werte', header_style),
+         Paragraph(t('total_gross_revenue_all_values').format(period=summary_data.get("tax_period", "")), header_style),
          '',
          "",
-                  Paragraph('''Falls <b>keine</b> Anrechnung ausländischer Quellensteuern (DA-1)
-geltend gemacht wird, sind diese Totalwerte im
-Wertschriftenverzeichnis einzusetzen.''', val_left)], # Col 5 << SHIFTED
+         Paragraph(t('instruction_no_da1'), val_left)], # Col 5 << SHIFTED
          # Row 7: Total Values (** SHIFTED RIGHT **, Indices 1, 2, 5 blank)
         [Paragraph(format_currency_rounded(summary_data.get('total_steuerwert')), val_right), # Col 0
          '',
@@ -577,7 +580,7 @@ Wertschriftenverzeichnis einzusetzen.''', val_left)], # Col 5 << SHIFTED
         # Add "Schulden" header only if there are liabilities
         if show_liabilities:
             header_row = [
-                Paragraph(f'<b>Schulden</b><br/>am {summary_data.get("period_end_date", "31.12")}', header_style),  # Col 0
+                Paragraph(t('liabilities_header').format(date=summary_data.get("period_end_date", "31.12")), header_style),  # Col 0
                 '',  # Col 1: blank
                 '',  # Col 2: blank
             ]
@@ -591,13 +594,13 @@ Wertschriftenverzeichnis einzusetzen.''', val_left)], # Col 5 << SHIFTED
 
         # Add "Schuldzinsen" header if there are liability payments
         if show_liability_payments:
-            header_row.append(Paragraph(f'<b>Schuldzinsen</b> {summary_data.get("tax_period", "")}', header_style))  # Col 6
+            header_row.append(Paragraph(t('liabilities_interest_summary_header').format(period=summary_data.get("tax_period", "")), header_style))  # Col 6
         else:
             header_row.append('')
 
         # Fill remaining columns (Cols 7-10, then Col 11 with description)
         header_row.extend(['', '', '', '',
-                          Paragraph('''Werte für zusätzliches Steuererklärungsformular <b>"Schuldenverzeichnis"</b>''', val_left)])
+                          Paragraph(t('instruction_liabilities_register'), val_left)])
 
         table_data.append(header_row)
 
@@ -764,15 +767,15 @@ def create_liabilities_table(tax_statement, styles, usable_width):
 
     table_data = [
         [
-            Paragraph('Datum', header_left),
-            Paragraph('Bezeichnung<br/>Schulden<br/>Zinsen', header_left),
-            Paragraph('Währung', header_style),
-            Paragraph('Schulden<br/>Schuldzinsen', header_style),
-            Paragraph('Kurs', header_style),
-            Paragraph(f'<b>Schulden</b><br/>{period_end_date}<br/>in CHF', header_style),
+            Paragraph(t('date'), header_left),
+            Paragraph(t('designation_liabilities_interest'), header_left),
+            Paragraph(t('currency'), header_style),
+            Paragraph(t('liabilities_amount_interest_header'), header_style),
+            Paragraph(t('exchange_rate'), header_style),
+            Paragraph(t('liabilities_amount_header').format(date=period_end_date), header_style),
             '',
             '',
-            Paragraph(f'<b>Schuldzinsen</b><br/>{year}<br/>in CHF', header_style),
+            Paragraph(t('liabilities_interest_header').format(year=year), header_style),
         ]
     ]
 
@@ -787,9 +790,9 @@ def create_liabilities_table(tax_statement, styles, usable_width):
         if (account.iban and account.iban != account.bankAccountName) or account.bankAccountNumber:
             account_desc += f"<br/>{escape_html_for_paragraph((account.iban if account.iban != account.bankAccountName else account.bankAccountNumber) or '')}"
         if account.openingDate:
-            account_desc += f"<br/>Eröffnung {account.openingDate.strftime('%d.%m.%Y')}"
+            account_desc += f"<br/>{t('opening').format(date=account.openingDate.strftime('%d.%m.%Y'))}"
         if account.closingDate:
-            account_desc += f"<br/>Saldierung {account.closingDate.strftime('%d.%m.%Y')}"
+            account_desc += f"<br/>{t('closing').format(date=account.closingDate.strftime('%d.%m.%Y'))}"
 
         # Add account header row
         table_data.append([
@@ -838,7 +841,7 @@ def create_liabilities_table(tax_statement, styles, usable_width):
 
         table_data.append([
             Paragraph(date_str, bold_left),
-            Paragraph('Schulden' if account.closingDate else 'Steuerwert / Schuldzinsen', bold_left),
+            Paragraph(t('liabilities') if account.closingDate else t('tax_value_liabilities_interest'), bold_left),
             Paragraph(currency_str, val_center),
             Paragraph(balance_str, val_right),
             Paragraph(exchange_rate_str, val_right),
@@ -857,7 +860,7 @@ def create_liabilities_table(tax_statement, styles, usable_width):
     # Add a final row with totals for the list of liabilities
     table_data.append([
         "",
-        Paragraph("Total Schulden", bold_left),
+        Paragraph(t('total_liabilities'), bold_left),
         '',
         '',
         '',
@@ -916,10 +919,10 @@ def create_costs_table(data, styles, usable_width):
     bold_left = styles['Bold_LEFT']
     bold_right = styles['Bold_RIGHT']
     period_end_date = data.get('summary', {}).get('period_end_date', '31.12')
-    table_data = [ [Paragraph('Bezeichnung', header_left_style), Paragraph('Spesentyp', header_left_style), Paragraph(f'Wert<br/>{period_end_date}<br/>in CHF', header_right_style)] ]
+    table_data = [ [Paragraph(t('description'), header_left_style), Paragraph(t('expense_type'), header_left_style), Paragraph(t('value_header').format(date=period_end_date), header_right_style)] ]
     total_costs = Decimal(0)
     for item in data['costs']: table_data.append([ Paragraph(item.get('description', ''), val_left), Paragraph(item.get('type', ''), val_left), Paragraph(format_currency_2dp(item.get('value_chf')), val_right) ]); total_costs += Decimal(str(item.get('value_chf', 0)))
-    table_data.append([ Paragraph('Total bezahlte Bankspesen', bold_left), Paragraph('', val_left), Paragraph(format_currency_2dp(total_costs), bold_right) ])
+    table_data.append([ Paragraph(t('total_paid_bank_fees'), bold_left), Paragraph('', val_left), Paragraph(format_currency_2dp(total_costs), bold_right) ])
     col_widths = [110*mm, 97*mm, 50*mm]
     assert sum(col_widths) < usable_width
     costs_table = Table(table_data, colWidths=col_widths)
@@ -938,17 +941,14 @@ def create_costs_table(data, styles, usable_width):
         ('TOPPADDING', (0, -1), (-1, -1), 1),
         ('BOTTOMPADDING', (0, -1), (-1, -1), 1),
     ]))
-    footnote_text = '(2) Über die Abzugsfähigkeit der Spesen entscheidet die zuständige Veranlagungsbehörde.'
+    footnote_text = t('expense_deductibility_notice')
     return KeepTogether([costs_table, Spacer(1, 2*mm), Paragraph(footnote_text, val_left)])
 
 
 # --- Info Box Helpers ---
 def create_minimal_placeholder(styles):
     """Create a placeholder paragraph for minimal tax statements."""
-    text = (
-        "Dies ist kein echter Steuerauszug. Dieses Minimaldokument dient nur dazu, "
-        "die Bankdaten über Barcodes zu importieren. Das die Totale nicht ermittelt werden wird auf eine Zusammenfassung verzichtet."
-    )
+    text = t('minimal_placeholder')
     return Paragraph(text, styles['Normal'])
 
 
@@ -1047,7 +1047,7 @@ def create_critical_warnings_flowables(warnings: list, styles, usable_width) -> 
     # Build table rows: title row + one row per warning
     rows = [
         [Paragraph(
-            "CRITICAL WARNINGS / KRITISCHE WARNUNGEN",
+            t('critical_warnings_title'),
             warning_title_style,
         )]
     ]
@@ -1104,11 +1104,8 @@ def create_critical_warnings_hint(warnings: list, styles) -> list:
     )
 
     n = len(warnings)
-    plural = "warning" if n == 1 else "warnings"
-    text = (
-        f"This statement has <b>{n}</b> critical {plural}. "
-        "Please review the information pages at the end of this document."
-    )
+    plural = t('warning') if n == 1 else t('warnings')
+    text = t('critical_warnings_hint').format(count=n, plural=plural)
 
     table = Table(
         [[Paragraph(text, hint_style)]],
@@ -1172,7 +1169,7 @@ def render_statement_info(tax_statement: TaxStatement, story: list, client_info_
         # Prepare client name with salutation
         salutation = ""
         if hasattr(client, 'salutation') and client.salutation:
-            salutation_codes = {"1": "", "2": "Herr", "3": "Frau"}
+            salutation_codes = {"1": "", "2": t('male'), "3": t('female')}
             salutation = salutation_codes.get(client.salutation, "")
         
         name_parts = []
@@ -1191,25 +1188,25 @@ def render_statement_info(tax_statement: TaxStatement, story: list, client_info_
     
     # Add client info to the PDF
     if client_name:
-        story.append(Paragraph(f"<b>Kunde:</b> {escape_html_for_paragraph(client_name)}", client_info_style))
+        story.append(Paragraph(f"<b>{t('client')}:</b> {escape_html_for_paragraph(client_name)}", client_info_style))
     if client_address:
-        story.append(Paragraph(f"<b>Adresse:</b> {escape_html_for_paragraph(client_address)}", client_info_style))
+        story.append(Paragraph(f"<b>{t('address')}:</b> {escape_html_for_paragraph(client_address)}", client_info_style))
     if portfolio:
-        story.append(Paragraph(f"<b>Portfolio:</b> {escape_html_for_paragraph(portfolio)}", client_info_style))
-    
+        story.append(Paragraph(f"<b>{t('portfolio')}:</b> {escape_html_for_paragraph(portfolio)}", client_info_style))
+
     # Period information with safe date handling
     period_from = tax_statement.periodFrom.strftime("%d.%m.%Y") if tax_statement.periodFrom else ""
     period_to = tax_statement.periodTo.strftime("%d.%m.%Y") if tax_statement.periodTo else ""
     
     # Period text with mandatory fields
     period_text = f"{period_from} - {period_to}"
-    story.append(Paragraph(f"<b>Periode:</b> {period_text}", client_info_style))
-    
+    story.append(Paragraph(f"<b>{t('period')}:</b> {period_text}", client_info_style))
+
     # Creation date
     if hasattr(tax_statement, 'creationDate') and tax_statement.creationDate:
         created_date = tax_statement.creationDate.strftime("%d.%m.%Y")
-        story.append(Paragraph(f"<b>Erstellt am:</b> {created_date}", client_info_style))
-    
+        story.append(Paragraph(f"<b>{t('created_at')}:</b> {created_date}", client_info_style))
+
     story.append(Spacer(1, 0.5*cm))
 
 
@@ -1231,7 +1228,7 @@ def render_to_barcodes(tax_statement: TaxStatement) -> list[PILImage.Image]:
     file_name = tax_statement.id
 
     # Follow Guidance in "Beilage zu eCH-0196 V2.2.0 – Barcode Generierung – Technische Wegleitung"
-    # our library foes not allow setting the row_count, so guess by making the segments roughly
+    # our library does not allow setting the row_count, so guess by making the segments roughly
     # right
     # Overhead:
     #    1  start word
@@ -1320,8 +1317,8 @@ def make_barcode_pages(doc: BarcodeDocTemplate, story: list, tax_statement: TaxS
     for page_num in range(barcode_pages):
         story.append(PageBreak('barcode'))
 
-        story.append(DocAssign("section_name", f"'Barcode Seite {page_num + 1} von {barcode_pages}'"))
-        story.append(Paragraph(f"Barcode Seite {page_num + 1} von {barcode_pages}", title_style))
+        story.append(DocAssign("section_name", f"'{t('barcode_page').format(page=page_num + 1, total=barcode_pages)}'"))
+        story.append(Paragraph(t('barcode_page').format(page=page_num + 1, total=barcode_pages), title_style))
         story.append(Spacer(0.1*cm, 0.5*cm))
         
         # Calculate start and end indices for this page
@@ -1396,18 +1393,18 @@ def create_bank_accounts_table(tax_statement, styles, usable_width):
     # Table header as specified
     table_data = [
         [
-            Paragraph('Datum', header_left),
-            Paragraph('Bezeichnung<br/>Bankkonto<br/>Zinsen', header_left),
-            Paragraph('Währung', header_style),
-            Paragraph('Steuerwert<br/>Ertrag', header_style),
-            Paragraph('Kurs', header_style),
-            Paragraph(f'<b>Steuerwert</b><br/>{period_end_date}<br/>in CHF', header_style),
+            Paragraph(t('date'), header_left),
+            Paragraph(t('designation_bank_account_interest'), header_left),
+            Paragraph(t('currency'), header_style),
+            Paragraph(t('tax_value_revenue_header'), header_style),
+            Paragraph(t('exchange_rate'), header_style),
+            Paragraph(t('tax_value_header').format(date=period_end_date), header_style),
             '',
-            Paragraph('<b>A</b>', header_style),
-            Paragraph(f'<b>Bruttoertrag</b><br/>{year} mit VSt.<br/>in CHF', header_style),
+            Paragraph(f'<b>{t("column_a")}</b>', header_style),
+            Paragraph(t('gross_revenue_with_vst_header').format(year=year), header_style),
             '',
-            Paragraph('<b>B</b>', header_style),
-            Paragraph(f'<b>Bruttoertrag</b><br/>{year} ohne VSt.<br/>in CHF', header_style),
+            Paragraph(f'<b>{t("column_b")}</b>', header_style),
+            Paragraph(t('gross_revenue_without_vst_header').format(year=year), header_style),
         ]
     ]
 
@@ -1420,9 +1417,9 @@ def create_bank_accounts_table(tax_statement, styles, usable_width):
         if (account.iban and account.iban != account.bankAccountName) or account.bankAccountNumber:
             account_desc += f"<br/>{escape_html_for_paragraph((account.iban if account.iban != account.bankAccountName else account.bankAccountNumber) or '')}"
         if account.openingDate:
-            account_desc += f"<br/>Eröffnung {account.openingDate.strftime('%d.%m.%Y')}"
+            account_desc += f"<br/>{t('opening').format(date=account.openingDate.strftime('%d.%m.%Y'))}"
         if account.closingDate:
-            account_desc += f"<br/>Saldierung {account.closingDate.strftime('%d.%m.%Y')}"
+            account_desc += f"<br/>{t('closing').format(date=account.closingDate.strftime('%d.%m.%Y'))}"
         table_data.append([
             '',
             Paragraph(account_desc, val_left),
@@ -1467,7 +1464,7 @@ def create_bank_accounts_table(tax_statement, styles, usable_width):
             currency_str = ''
         table_data.append([
             Paragraph(date_str, bold_left),
-            Paragraph('Auflösung / Ertrag' if account.closingDate else 'Steuerwert / Ertrag', bold_left),
+            Paragraph(t('dissolution_revenue') if account.closingDate else t('tax_value_revenue'), bold_left),
             Paragraph(currency_str, val_center),
             Paragraph(balance_str, val_right),
             Paragraph(exchange_rate_str, val_right),
@@ -1484,7 +1481,7 @@ def create_bank_accounts_table(tax_statement, styles, usable_width):
     # add a final with totals for the list of bank accounts
     table_data.append([
         "",
-        Paragraph("Total Bankkonten", bold_left),
+        Paragraph(t('total_bank_accounts'), bold_left),
         '',
         '',
         '',
@@ -1550,23 +1547,21 @@ def create_securities_table(tax_statement, styles, usable_width, security_type: 
     bold_right = styles['Bold_RIGHT']
 
     # Table header with security type in the title
-    type_label = {"A": "mit VSt.-Abzug", "B": "ohne VSt.-Abzug", "DA1": "DA-1 und USA-Werte"}
-    
     table_header = [
-        Paragraph('Valoren-Nr<br/>Datum', header_left),
-        Paragraph('Depot-Nr<br/>Bezeichnung<br/>ISIN', header_left),
-        Paragraph('Anzahl<br/>Nominal', header_style),
-        Paragraph('Währung<br/>Land', header_style),
-        Paragraph('Stückpreis<br/>Nominal<br/>Ertrag', header_style),
-        Paragraph('Ex-<br/>Datum', header_left),
-        Paragraph('Kurs', header_style),
-        Paragraph(f'<b>Steuerwert</b> {period_end_date}<br/>in CHF', header_style),
-        Paragraph('A', header_style),
-        Paragraph(f'<b>Bruttoertrag</b> {year} mit VSt. in CHF', header_style),
-        Paragraph('B', header_style),
-        Paragraph(f'<b>Bruttoertrag</b> {year} ohne VSt. in CHF', header_style),
-        Paragraph('<b>Anrechenbare ausl. Quellen- steuer</b> in CHF', header_style),
-        Paragraph('<b>Steuerrückbehalt USA</b><br/>in CHF', header_style),
+        Paragraph(t('valor_number_date'), header_left),
+        Paragraph(t('depot_number_designation_isin'), header_left),
+        Paragraph(t('quantity_nominal'), header_style),
+        Paragraph(t('currency_country'), header_style),
+        Paragraph(t('unit_price_nominal_revenue'), header_style),
+        Paragraph(t('ex_date_short'), header_left),
+        Paragraph(t('exchange_rate'), header_style),
+        Paragraph(t('tax_value_date').format(date=period_end_date), header_style),
+        Paragraph(t('column_a'), header_style),
+        Paragraph(t('gross_revenue_with_vst_year').format(year=year), header_style),
+        Paragraph(t('column_b'), header_style),
+        Paragraph(t('gross_revenue_without_vst_year').format(year=year), header_style),
+        Paragraph(t('foreign_tax_credit'), header_style),
+        Paragraph(t('usa_withholding'), header_style),
     ]
     
     col_widths = [22*mm, 54*mm, 20*mm, 18*mm, 18*mm, 14*mm, 18*mm, 22*mm, 8, 22*mm, 8, 22*mm, 25*mm, 25*mm]
@@ -1609,7 +1604,7 @@ def create_securities_table(tax_statement, styles, usable_width, security_type: 
     
     for depot, securities_in_depot in filtered_securities_by_depot:
         # Add depot header row
-        depot_header_text = f"<b>Depot {depot.depotNumber or ''}</b>"
+        depot_header_text = t('depot').format(number=depot.depotNumber or '')
         depot_header_row = [
             Paragraph('', val_left),
             Paragraph(depot_header_text, bold_left),
@@ -1713,7 +1708,7 @@ def create_securities_table(tax_statement, styles, usable_width, security_type: 
                     if entry.mutation:
                         name = entry.name
                     else:
-                        name = "Saldo"
+                        name = t('balance')
                     table_data.append([
                         Paragraph(entry.referenceDate.strftime("%d.%m.%Y") if entry.referenceDate else '', val_left),
                         Paragraph(name, val_left),
@@ -1744,10 +1739,10 @@ def create_securities_table(tax_statement, styles, usable_width, security_type: 
             if tax_value and getattr(tax_value, 'unitPrice', None):
                 unit_price = format_currency(tax_value.unitPrice)
             elif tax_value and getattr(tax_value, 'undefined', None):
-                unit_price = "n.v."
+                unit_price = t('na')
             table_data.append([
                 Paragraph(date_str, bold_left),
-                Paragraph('Bestand / Steuerwert / Ertrag', bold_left),
+                Paragraph(t('stock_tax_value_revenue'), bold_left),
                 Paragraph(format_stock_quantity(tax_value.quantity, False, stock_quantity_template) if tax_value else '0', val_right),
                 Paragraph(tax_value.balanceCurrency or '' if tax_value else '', val_right),
                 Paragraph(unit_price, val_right),
@@ -1771,18 +1766,21 @@ def create_securities_table(tax_statement, styles, usable_width, security_type: 
         total_tax_value = tax_statement.svTaxValueA
         total_gross_revenueA = tax_statement.svGrossRevenueA
         total_gross_revenueB = Decimal('0')
+        total_label = t('total_a_values')
     elif security_type == "B":
         total_tax_value = tax_statement.svTaxValueB
         total_gross_revenueA = Decimal('0')
         total_gross_revenueB = tax_statement.svGrossRevenueB
+        total_label = t('total_b_values')
     elif security_type == "DA1":
         total_tax_value = tax_statement.da1TaxValue
         total_gross_revenueA = Decimal('0')
         total_gross_revenueB = tax_statement.da_GrossRevenue
+        total_label = t('total_da1_usa')
     # Add a total row
     table_data.append([
         Paragraph('', val_left),
-        Paragraph(f'Total {security_type}-Werte' if security_type != "DA1" else 'Total Anrechnung ausländischer Quellensteuer / zusätzlicher Steuerrückbehalt USA', bold_left),
+        Paragraph(total_label, bold_left),
         Paragraph('', val_right),
         Paragraph('', val_center),
         Paragraph('', val_right),
@@ -1852,16 +1850,16 @@ def create_payment_reconciliation_tables(tax_statement: TaxStatement, styles, us
     flowables = []
     for country in sorted(grouped.keys()):
         rows = sorted(grouped[country], key=lambda r: (r.security, r.payment_date))
-        flowables.append(Paragraph(f"Abgleich Zahlungen ({country})", styles['h2']))
+        flowables.append(Paragraph(t('reconciliation_payments').format(country=country), styles['h2']))
 
         table_header = [
-            Paragraph('Wertschrift', styles['Header_LEFT']),
-            Paragraph('Datum', styles['Header_LEFT']),
-            Paragraph('KL Div CHF', header_style),
-            Paragraph('KL Quellenst. CHF', header_style),
-            Paragraph('Broker Div', header_style),
-            Paragraph('Broker Quellenst.', header_style),
-            Paragraph('OK', header_style),
+            Paragraph(t('security'), styles['Header_LEFT']),
+            Paragraph(t('date'), styles['Header_LEFT']),
+            Paragraph(t('kl_dividend_chf'), header_style),
+            Paragraph(t('kl_withholding_chf'), header_style),
+            Paragraph(t('broker_dividend'), header_style),
+            Paragraph(t('broker_withholding'), header_style),
+            Paragraph(t('ok'), header_style),
         ]
         data = []
         mismatch_rows = []
@@ -1931,6 +1929,7 @@ def render_tax_statement(
     output_path: Union[str, Path],
     override_org_nr: Optional[str] = None,
     minimal_frontpage_placeholder: bool = False,
+    language: str = DEFAULT_LANGUAGE,
 ) -> Path:
     """Render a tax statement to PDF.
     
@@ -1940,10 +1939,15 @@ def render_tax_statement(
         override_org_nr: Optional override for organization number (5 digits)
         minimal_frontpage_placeholder: If True, replace the summary on the first
             page with a placeholder suitable for minimal tax statements
-        
+        language: Language code for translations (default: 'de')
+
     Returns:
         Path to the generated PDF file
     """
+    # Set the module-level language context for this rendering
+    global _current_language
+    _current_language = language
+
     # Convert to string path if it's a Path object
     output_path = str(output_path) if isinstance(output_path, Path) else output_path
     
@@ -1996,7 +2000,7 @@ def render_tax_statement(
 
     # Set the PDF title using institution name and tax year
     tax_year = str(tax_statement.taxPeriod) if tax_statement.taxPeriod else ""
-    title_parts = ["Steuerauszug", doc.company_name, tax_year]
+    title_parts = [t('taxstatement'), doc.company_name, tax_year]
     doc.title = " ".join(part for part in title_parts if part)
     
     # Extract and store client information for header display (backward compatibility)
@@ -2023,7 +2027,7 @@ def render_tax_statement(
     use_minimal_frontpage = minimal_frontpage_placeholder
 
     # 1. Summary Section or placeholder
-    story.append(Paragraph("Zusammenfassung", title_style))
+    story.append(Paragraph(t('summary'), title_style))
 
     critical_warnings = tax_statement.critical_warnings or []
 
@@ -2101,7 +2105,7 @@ def render_tax_statement(
     bank_table = create_bank_accounts_table(tax_statement, styles, usable_width)
     if bank_table:
         story.append(PageBreak())
-        story.append(Paragraph("Bankkonten", title_style))
+        story.append(Paragraph(t('bank_accounts'), title_style))
         story.append(bank_table)
         story.append(Spacer(1, 0.5*cm))
 
@@ -2109,7 +2113,7 @@ def render_tax_statement(
     securities_table_a = create_securities_table(tax_statement, styles, usable_width, "A")
     if securities_table_a:
         story.append(PageBreak())
-        story.append(Paragraph("A-Werte mit Verrechnungssteuerabzug", title_style))
+        story.append(Paragraph(t('a_values_with_vst'), title_style))
         story.append(securities_table_a)
         story.append(Spacer(1, 0.5*cm))
     
@@ -2117,7 +2121,7 @@ def render_tax_statement(
     securities_table_b = create_securities_table(tax_statement, styles, usable_width, "B")
     if securities_table_b:
         story.append(PageBreak())
-        story.append(Paragraph("B-Werte ohne Verrechnungssteuerabzug", title_style))
+        story.append(Paragraph(t('b_values_without_vst'), title_style))
         story.append(securities_table_b)
         story.append(Spacer(1, 0.5*cm))
     
@@ -2125,7 +2129,7 @@ def render_tax_statement(
     securities_table_da1 = create_securities_table(tax_statement, styles, usable_width, "DA1")
     if securities_table_da1:
         story.append(PageBreak())
-        story.append(Paragraph("Werte mit Anrechnung ausländischer Quellensteuer / zusätzlicher Steuerrückbehalt USA", title_style))
+        story.append(Paragraph(t('values_with_da1_usa'), title_style))
         story.append(securities_table_da1)
         story.append(Spacer(1, 0.5*cm))
 
@@ -2133,7 +2137,7 @@ def render_tax_statement(
     liabilities_table = create_liabilities_table(tax_statement, styles, usable_width)
     if liabilities_table:
         story.append(PageBreak())
-        story.append(Paragraph("Schulden", title_style))
+        story.append(Paragraph(t('liabilities_title'), title_style))
         story.append(liabilities_table)
         story.append(Spacer(1, 0.5*cm))
 
@@ -2141,7 +2145,7 @@ def render_tax_statement(
     reconciliation_flowables = create_payment_reconciliation_tables(tax_statement, styles, usable_width)
     if reconciliation_flowables:
         story.append(PageBreak())
-        story.append(Paragraph("Abgleich Kursliste / Brokerzahlungen", title_style))
+        story.append(Paragraph(t('reconciliation_kursliste_broker'), title_style))
         story.extend(reconciliation_flowables)
 
     # Info pages before the barcode

--- a/src/opensteuerauszug/render/translations/__init__.py
+++ b/src/opensteuerauszug/render/translations/__init__.py
@@ -1,0 +1,11 @@
+"""Translation management package for PDF rendering.
+
+This package provides translation functionality with support for multiple languages.
+Translations are loaded from separate language files (de.py, fr.py, etc.) in this directory.
+"""
+
+from .manager import t, get_text, clear_translation_cache, DEFAULT_LANGUAGE
+
+__all__ = ['t', 'get_text', 'clear_translation_cache', 'DEFAULT_LANGUAGE']
+
+

--- a/src/opensteuerauszug/render/translations/de.py
+++ b/src/opensteuerauszug/render/translations/de.py
@@ -1,0 +1,136 @@
+"""German translations for PDF rendering."""
+
+TRANSLATIONS = {
+    # === DOCUMENT METADATA ===
+    'created_with': 'erstellt mit OpenSteuerauszug',
+    'converted_with': 'konvertiert mit OpenSteuerauszug',
+    'taxstatement': 'Steuerauszug',
+
+    # === PAGE STRUCTURE ===
+    'page': 'Seite {page} von {total}',
+
+    # === CLIENT INFORMATION ===
+    'client': 'Kunde',
+    'client_number': 'Kdnr.',
+    'male': 'Herr',
+    'female': 'Frau',
+    'address': 'Adresse',
+    'canton': 'Kanton',
+    'period': 'Periode',
+    'portfolio': 'Portfolio',
+    'created_at': 'Erstellt am',
+
+    # === SECTION TITLES ===
+    'summary': 'Zusammenfassung',
+    'bank_accounts': 'Bankkonten',
+    'a_values_with_vst': 'A-Werte mit Verrechnungssteuerabzug',
+    'b_values_without_vst': 'B-Werte ohne Verrechnungssteuerabzug',
+    'values_with_da1_usa': 'Werte mit Anrechnung ausländischer Quellensteuer / zusätzlicher Steuerrückbehalt USA',
+    'liabilities': 'Schulden',
+    'liabilities_title': 'Schulden',
+    'reconciliation_kursliste_broker': 'Abgleich Kursliste / Brokerzahlungen',
+    'tax_statement_in_chf': 'Steuerauszug in CHF',
+
+    # === BARCODE PAGE ===
+    'barcode_page': 'Barcode Seite {page} von {total}',
+
+    # === COMMON LABELS ===
+    'date': 'Datum',
+    'description': 'Bezeichnung',
+    'currency': 'Währung',
+    'exchange_rate': 'Kurs',
+    'data_from': 'Daten von',
+    'na': 'n.v.',
+    'column_a': 'A',
+    'column_b': 'B',
+
+    # === SUMMARY TABLE HEADERS ===
+    'tax_value_ab_header': '<b>Steuerwert</b> der<br/><b>A</b>- und <b>B</b>-Werte am {date}',
+    'gross_revenue_values_with_vst': '<b>Bruttoertrag</b><br/>{period} Werte <b>mit</b> VSt.-Abzug',
+    'gross_revenue_values_without_vst': '<b>Bruttoertrag</b><br/>{period} Werte <b>ohne</b> VSt.-Abzug',
+    'withholding_tax_claim': 'Verrechnungs- steueranspruch',
+    'tax_value_da1_usa_header': '<b>Steuerwert</b> der <b>DA-1</b> und <b>USA</b>- Werte am {date}',
+    'gross_revenue_da1_usa_header': '<b>Bruttoertrag</b> {period}<br/><b>DA-1</b> und <b>USA</b>-Werte',
+    'withholding_usa': 'Steuerrückbehalt USA',
+    'foreign_tax_credit_header': 'Anrechnung ausländischer Quellensteuer',
+    'total_tax_value_header': '<b>Total Steuerwert</b> der <b>A, B, DA-1</b> und <b>USA</b>-Werte am {date}',
+    'total_gross_revenue_a_with_vst': '<b>Total Bruttoertrag</b> {period} <b>A</b>-Werte <b>mit</b><br/>VSt.-Abzug',
+    'total_gross_revenue_b_da1_usa_without_vst': '<b>Total Bruttoertrag</b> {period} <b>B, DA-1</b> und <b>USA</b>-Werte <b>ohne</b> VSt.-Abzug',
+    'total_gross_revenue_all_values': '<b>Total Bruttoertrag</b> {period} <b>A, B, DA-1</b> und <b>USA</b>-Werte',
+    'liabilities_header': '<b>Schulden</b><br/>am {date}',
+    'liabilities_interest_summary_header': '<b>Schuldzinsen</b> {period}',
+
+    # === BANK ACCOUNTS TABLE ===
+    'total_bank_accounts': 'Total Bankkonten',
+    'designation_bank_account_interest': 'Bezeichnung<br/>Bankkonto<br/>Zinsen',
+    'total_steuerwert': 'Total Steuerwert',
+    'opening': 'Eröffnung {date}',
+    'closing': 'Saldierung {date}',
+    'value_header': 'Wert<br/>{date}<br/>in CHF',
+    'total_paid_bank_fees': 'Total bezahlte Bankspesen',
+    'tax_value_revenue': 'Steuerwert / Ertrag',
+    'dissolution_revenue': 'Auflösung / Ertrag',
+
+    # === SECURITIES TABLE ===
+    'valor_number_date': 'Valoren-Nr<br/>Datum',
+    'depot_number_designation_isin': 'Depot-Nr<br/>Bezeichnung<br/>ISIN',
+    'quantity_nominal': 'Anzahl<br/>Nominal',
+    'currency_country': 'Währung<br/>Land',
+    'unit_price_nominal_revenue': 'Stückpreis<br/>Nominal<br/>Ertrag',
+    'ex_date_short': 'Ex-<br/>Datum',
+    'tax_value_header': '<b>Steuerwert</b><br/>{date}<br/>in CHF',
+    'tax_value_date': '<b>Steuerwert</b> {date}<br/>in CHF',
+    'tax_value_revenue_header': 'Steuerwert<br/>Ertrag',
+    'gross_revenue_with_vst_header': '<b>Bruttoertrag</b><br/>{year} mit VSt.<br/>in CHF',
+    'gross_revenue_without_vst_header': '<b>Bruttoertrag</b><br/>{year} ohne VSt.<br/>in CHF',
+    'gross_revenue_with_vst_year': '<b>Bruttoertrag</b> {year} mit VSt. in CHF',
+    'gross_revenue_without_vst_year': '<b>Bruttoertrag</b> {year} ohne VSt. in CHF',
+    'depot': '<b>Depot {number}</b>',
+    'balance': 'Saldo',
+    'stock_tax_value_revenue': 'Bestand / Steuerwert / Ertrag',
+    'total_a_values': 'Total A-Werte',
+    'total_b_values': 'Total B-Werte',
+    'total_da1_usa': 'Total Anrechnung ausländischer Quellensteuer / zusätzlicher Steuerrückbehalt USA',
+    'foreign_tax_credit': '<b>Anrechenbare ausl. Quellen- steuer</b> in CHF',
+    'usa_withholding': '<b>Steuerrückbehalt USA</b><br/>in CHF',
+
+    # === LIABILITIES TABLE ===
+    'designation_liabilities_interest': 'Bezeichnung<br/>Schulden<br/>Zinsen',
+    'liabilities_amount_interest_header': 'Schulden<br/>Schuldzinsen',
+    'liabilities_amount_header': '<b>Schulden</b><br/>{date}<br/>in CHF',
+    'liabilities_interest_header': '<b>Schuldzinsen</b><br/>{year}<br/>in CHF',
+    'tax_value_liabilities_interest': 'Steuerwert / Schuldzinsen',
+    'total_liabilities': 'Total Schulden',
+
+    # === PAYMENT RECONCILIATION TABLE ===
+    'reconciliation_payments': 'Abgleich Zahlungen ({country})',
+    'kl_dividend_chf': 'KL Div CHF',
+    'kl_withholding_chf': 'KL Quellenst. CHF',
+    'broker_dividend': 'Broker Div',
+    'broker_withholding': 'Broker Quellenst.',
+    'ok': 'OK',
+    'security': 'Wertschrift',
+
+    # === INSTRUCTIONS & FOOTNOTES ===
+    'footnote_ab_breakdown': '(1) Davon <b>A</b> {} und <b>B</b> {}',
+    'instruction_securities_register': 'Werte für Formular <b>"Wertschriften- und Guthabenverzeichnis"</b>\n(inkl. Konti, ohne Werte DA-1 und USA)',
+    'instruction_da1_form': 'Werte für zusätzliches Formular <b>"DA-1 Antrag auf Anrechnung\nausländischer Quellensteuer und zusätzlichen Steuerrückbehalt\nUSA"</b> (DA-1)',
+    'instruction_no_da1': '''Falls <b>keine</b> Anrechnung ausländischer Quellensteuern (DA-1)
+geltend gemacht wird, sind diese Totalwerte im
+Wertschriftenverzeichnis einzusetzen.''',
+    'instruction_liabilities_register': '''Werte für zusätzliches Steuererklärungsformular <b>"Schuldenverzeichnis"</b>''',
+    'expense_deductibility_notice': '(2) Über die Abzugsfähigkeit der Spesen entscheidet die zuständige Veranlagungsbehörde.',
+
+    # === EXPENSE INFORMATION ===
+    'expense_type': 'Spesentyp',
+
+    # === PLACEHOLDERS ===
+    'minimal_placeholder': '''Dies ist kein echter Steuerauszug. Dieses Minimaldokument dient nur dazu, die Bankdaten über Barcodes zu importieren. Da die Totale nicht ermittelt werden, wird auf eine Zusammenfassung verzichtet.''',
+
+    # === CRITICAL WARNINGS ===
+    'critical_warnings_title': 'CRITICAL WARNINGS / KRITISCHE WARNUNGEN',
+    'warning': 'warning',
+    'warnings': 'warnings',
+    'critical_warnings_hint': 'This statement has <b>{count}</b> critical {plural}. Please review the information pages at the end of this document.',
+}
+

--- a/src/opensteuerauszug/render/translations/manager.py
+++ b/src/opensteuerauszug/render/translations/manager.py
@@ -1,0 +1,94 @@
+"""Translation management for PDF rendering.
+
+This module provides translation functionality with support for multiple languages.
+Translations are loaded from separate language files in the translations/ subfolder.
+Falls back to German ('de') if a translation is missing in the requested language.
+"""
+
+import importlib
+import logging
+from typing import Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# Cache for loaded translation modules
+_translation_cache: Dict[str, Dict[str, str]] = {}
+
+# Default language
+DEFAULT_LANGUAGE = 'de'
+
+
+def _load_translations(lang: str) -> Optional[Dict[str, str]]:
+    """Load translations for a specific language.
+
+    Args:
+        lang: The language code (e.g., 'de', 'fr', 'en')
+
+    Returns:
+        Dictionary of translations or None if language file doesn't exist
+    """
+    if lang in _translation_cache:
+        return _translation_cache[lang]
+
+    try:
+        # Dynamically import the language module
+        module = importlib.import_module(f'opensteuerauszug.render.translations.{lang}')
+        translations = getattr(module, 'TRANSLATIONS', {})
+        _translation_cache[lang] = translations
+        logger.debug(f"Loaded {len(translations)} translations for language '{lang}'")
+        return translations
+    except (ImportError, AttributeError) as e:
+        logger.warning(f"Could not load translations for language '{lang}': {e}")
+        return None
+
+
+def get_text(key: str, lang: str = DEFAULT_LANGUAGE) -> str:
+    """Get translated text for a given key.
+
+    Falls back to default language if the translation is not found in the requested language.
+
+    Args:
+        key: The translation key
+        lang: The language code (default: 'de')
+
+    Returns:
+        The translated text, or the key itself if not found in any language
+    """
+    # Try to get translation in requested language
+    translations = _load_translations(lang)
+    if translations and key in translations:
+        return translations[key]
+
+    # Fallback to default language if different language was requested
+    if lang != DEFAULT_LANGUAGE:
+        logger.debug(f"Translation key '{key}' not found in '{lang}', falling back to '{DEFAULT_LANGUAGE}'")
+        default_translations = _load_translations(DEFAULT_LANGUAGE)
+        if default_translations and key in default_translations:
+            return default_translations[key]
+
+    # If still not found, return the key itself
+    logger.warning(f"Translation key '{key}' not found in any language, returning key as fallback")
+    return key
+
+
+def t(key: str, lang: str = DEFAULT_LANGUAGE) -> str:
+    """Shorthand alias for get_text.
+
+    Args:
+        key: The translation key
+        lang: The language code (default: 'de')
+
+    Returns:
+        The translated text, or the key itself if not found
+    """
+    return get_text(key, lang)
+
+
+def clear_translation_cache():
+    """Clear the translation cache.
+
+    Useful for testing or if translation files are modified at runtime.
+    """
+    _translation_cache.clear()
+    logger.debug("Translation cache cleared")
+

--- a/src/opensteuerauszug/steuerauszug.py
+++ b/src/opensteuerauszug/steuerauszug.py
@@ -8,7 +8,7 @@ from datetime import date, datetime
 from pypdf import PdfReader, PdfWriter
 
 from opensteuerauszug.config.models import SchwabAccountSettings, IbkrAccountSettings, GeneralSettings # Added GeneralSettings
-import os # For path construction
+from opensteuerauszug.render.translations import DEFAULT_LANGUAGE
 from .core.identifier_loader import SecurityIdentifierMapLoader
 
 # Use the generated eCH-0196 model
@@ -617,6 +617,11 @@ def main(
                         if general_config_settings
                         else True
                     )
+                ),
+                language=(
+                    general_config_settings.language
+                    if general_config_settings
+                    else DEFAULT_LANGUAGE
                 ),
             )
             print(f"Rendering successful to {rendered_path}")


### PR DESCRIPTION
This change just extracts translations from render.py (importers are not affected yet).
This change does not change any translations. Output is 1:1 equal.
Translations for other languages will be added in a follow-up change.

I have also looked into a `gettext` based approach, but this might be an overkill for our needs where translations are quite static.