### PR TITLE
fix(schwab): handle Security Transfer and Qual Div Reinvest actions

### DIFF
--- a/src/opensteuerauszug/importers/schwab/transaction_extractor.py
+++ b/src/opensteuerauszug/importers/schwab/transaction_extractor.py
@@ -13,8 +13,8 @@ logger = logging.getLogger(__name__)
 # Known actions from formats.md
 KNOWN_ACTIONS = {
     "Buy", "Cash In Lieu", "Credit Interest", "Deposit", "Dividend", "Journal",
-    "NRA Tax Adj", "Reinvest Dividend", "Reinvest Shares", "Sale", "Sell", "Stock Plan Activity", "Stock Split",
-    "Tax Withholding", "Transfer", "Wire Transfer"
+    "NRA Tax Adj", "Reinvest Dividend", "Qual Div Reinvest", "Reinvest Shares", "Sale", "Sell", "Stock Plan Activity", "Stock Split",
+    "Tax Withholding", "Transfer", "Security Transfer", "Wire Transfer"
 }
 
 class TransactionExtractor:
@@ -348,7 +348,7 @@ class TransactionExtractor:
                 # Cash stock mutation
                 cash_stock = create_cash_stock(schwab_amount, f"Cash in for Credit Interest")
 
-        elif action == "Dividend" or action == "Reinvest Dividend":
+        elif action == "Dividend" or action == "Reinvest Dividend" or action == "Qual Div Reinvest":
             if schwab_amount and schwab_amount > 0 and isinstance(pos_object, SecurityPosition):
                 if schwab_qty is not None and schwab_qty != Decimal(0):
                     print(f"Warning: Ignoring non-zero quantity ({schwab_qty}) for action '{action}' on symbol {pos_object.symbol}. Payment quantity will be uninitialized.")
@@ -461,15 +461,14 @@ class TransactionExtractor:
             if schwab_amount:
                 cash_stock = create_cash_stock(schwab_amount, f"Wire Transfer{' ' + pos_object.symbol if isinstance(pos_object, SecurityPosition) else ''}")
 
-        elif action == "Transfer":
+        elif action == "Transfer" or action == "Security Transfer":
             if schwab_qty and schwab_tx.get("Symbol") and isinstance(pos_object, SecurityPosition): # Share transfer
-                # No cash flow for transfer
-                assert not schwab_amount
-                assert schwab_qty > 0
+                # Schwab transfer rows represent shares moving out of this account.
+                final_qty = -abs(schwab_qty)
 
                 sec_stock = SecurityStock(
                     referenceDate=tx_date, mutation=True, quotationType="PIECE",
-                    quantity=-schwab_qty, balanceCurrency=currency, # Use currency string
+                    quantity=final_qty, balanceCurrency=currency, # Use currency string
                     unitPrice=schwab_price, name="Transfer (Shares)",
                 )
 

--- a/tests/importers/schwab/test_transaction_extractor.py
+++ b/tests/importers/schwab/test_transaction_extractor.py
@@ -374,6 +374,46 @@ class TestSchwabTransactionExtractor:
         assert cash_stock_entry.referenceDate == date(2024, 7, 1), "Reference date should match transaction date"
         assert cash_stock_entry.mutation is True, "Cash stock entry should be a mutation"
         assert cash_stock_entry.quantity == Decimal("555.65")
+
+    def test_action_qual_div_reinvest(self):
+        extractor = create_extractor()
+        data = {
+            "FromDate": "01/01/2025", "ToDate": "12/31/2025",
+            "BrokerageTransactions": [{
+                "Date": "02/13/2025", "Action": "Qual Div Reinvest", "Symbol": "AAPL",
+                "Description": "APPLE INC", "Amount": "$10.18"
+            }]
+        }
+        result = run_extraction_test(extractor, data, 2)
+        assert result is not None
+
+        aapl_data = find_position(result, SecurityPosition, "AAPL")
+        cash_data = find_position(result, CashPosition)
+        assert aapl_data is not None
+        assert cash_data is not None
+
+        pos, stocks, payments = aapl_data
+        assert isinstance(pos, SecurityPosition)
+        assert pos.symbol == "AAPL"
+        assert stocks is not None
+        assert len(stocks) == 0
+        assert payments is not None
+        assert len(payments) == 1
+        payment = payments[0]
+        assert payment.name == "Dividend"
+        assert payment.grossRevenueB == Decimal("10.18")
+        assert payment.amount == Decimal("10.18")
+
+        cash_pos, cash_stocks, cash_payments = cash_data
+        assert isinstance(cash_pos, CashPosition)
+        assert cash_payments is None
+        assert cash_stocks is not None
+        assert len(cash_stocks) == 1
+        cash_stock_entry = cash_stocks[0]
+        assert cash_stock_entry.referenceDate == date(2025, 2, 13)
+        assert cash_stock_entry.mutation is True
+        assert cash_stock_entry.quantity == Decimal("10.18")
+        assert cash_stock_entry.name == "Cash in for Dividend AAPL"
  
     def test_action_stock_split(self):
         extractor = create_extractor()
@@ -667,6 +707,29 @@ class TestSchwabTransactionExtractor:
         stock = stocks[0]
         assert stock.quantity == -Decimal("5.0")
         assert stock.name is not None
+        assert stock.name == "Transfer (Shares)"
+
+    def test_action_security_transfer_negative_quantity_stays_outflow(self):
+        extractor = create_extractor()
+        data = {
+            "FromDate": "01/01/2025", "ToDate": "12/31/2025",
+            "BrokerageTransactions": [{
+                "Date": "12/01/2025", "Action": "Security Transfer", "Symbol": "VT",
+                "Description": "VANGUARD TOTAL WORLD STOCK ETF",
+                "Quantity": "-42", "Amount": ""
+            }]
+        }
+        result = run_extraction_test(extractor, data, 1)
+        assert result is not None
+        vt_data = find_position(result, SecurityPosition, "VT")
+        assert vt_data is not None
+
+        pos, stocks, payments = vt_data
+        assert isinstance(pos, SecurityPosition)
+        assert payments is None
+        assert len(stocks) == 1
+        stock = stocks[0]
+        assert stock.quantity == Decimal("-42")
         assert stock.name == "Transfer (Shares)"
  
     def test_action_transfer_cash_in(self):


### PR DESCRIPTION
Recognize Schwab action labels that previously caused importer failures.

Support in parser:
- Security Transfer in transfer handling
- Qual Div Reinvest handled in outflow normalization via -abs(quantity)
- KNOWN_ACTIONS includes Security Transfer and Qual Div Reinvest

Tests:
- add dedicated regression test for Security Transfer
- add dedicated regression test for Qual Div Reinvest payment mapping

Fixes #257