### PR TITLE
Document stock request process for Kursliste

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -170,9 +170,7 @@ If a stock cannot be found in the Kursliste you can request the addition of the 
 
 Send an email with the ISIN and company name to:
 
-- wefin.dvs@estv.admin.ch  
-- evestv.admin@zh.ch  
-- dvs@estv.admin.ch  
+- dvs at estv.admin.ch  
 
 Example email:
 


### PR DESCRIPTION
This PR adds documentation explaining how users can request the inclusion of missing securities in the ESTV Kursliste.
Described on the issue https://github.com/vroonhof/opensteuerauszug/issues/282

Sometimes US stocks or less common securities are not yet available in the official list. The documentation now explains that users can email ESTV with the ISIN to request inclusion, which is typically processed quickly and then appears in the next XML update.