### PR TITLE
test: use sys.executable instead of python

### DIFF
--- a/tests/scripts/test_convert_kursliste_to_sqlite.py
+++ b/tests/scripts/test_convert_kursliste_to_sqlite.py
@@ -1,6 +1,7 @@
 import pytest
 import subprocess
 import sqlite3
+import sys
 from pathlib import Path
 from decimal import Decimal
 import json # Added for model_validate_json
@@ -75,7 +76,7 @@ def test_convert_kursliste_xml_to_sqlite(tmp_path):
     # If this test file is in tests/scripts/, then SCRIPT_PATH needs to be adjusted.
     # Assuming SCRIPT_PATH is correctly defined relative to where pytest is run.
     cmd = [
-        "python", str(SCRIPT_PATH),
+        sys.executable, str(SCRIPT_PATH),
         str(sample_xml_file),
         str(output_db_file)
     ]


### PR DESCRIPTION
### Description

This PR fixes a potential environment issue in tests/scripts/test_convert_kursliste_to_sqlite.py by replacing the hardcoded "python" command string with sys.executable.

### Why is this needed?

When tests are executed using pytest, especially within a CI pipeline or a virtual environment (e.g., .venv), it is crucial that any subprocesses spawned by the tests execute within the same isolated Python environment. 
Using "python" relies on the system's PATH resolution at the time the subprocess is spawned. This can lead to unpredictable behavior where the subprocess unintentionally escapes the virtual environment and uses the global system Python installation. If the system Python is missing required dependencies or is a different version, the test will fail unpredictably.
Furthermore, on modern macOS and some Linux distributions, the command "python" may not be symlinked to "python3", causing a FileNotFoundError.

### How does sys.executable solve this?

`sys.executable` evaluates to the absolute path of the specific Python interpreter currently executing the test suite. This guarantees perfect consistency between the test runner and the child process, ensuring the subprocess always runs inside the correct, active environment.

### Changes Made

- Imported the sys module in tests/scripts/test_convert_kursliste_to_sqlite.py.
- Replaced the string literal "python" with sys.executable in the subprocess.run command list.