### PR TITLE
Do not render trailing 0 in XML

### DIFF
--- a/src/opensteuerauszug/model/ech0196.py
+++ b/src/opensteuerauszug/model/ech0196.py
@@ -421,8 +421,8 @@ class BaseXmlModel(BaseModel):
                         # TODO: Implement base64 encoding if needed for fileData
                         raise NotImplementedError("Base64 encoding is not implemented")
                     elif isinstance(value, Decimal):
-                        # Format Decimal as a plain string to avoid scientific notation
-                        str_value = f'{value:f}'
+                        # Format Decimal as a plain string to avoid scientific notation and remove trailing zeros
+                        str_value = format(value.normalize(), "f")
                     else:
                         str_value = str(value)
                     element.set(attr_name, str_value)

--- a/tests/samples/fake_statement.xml
+++ b/tests/samples/fake_statement.xml
@@ -10,10 +10,10 @@
               periodTo="2024-12-31"
               country="CH"
               canton="ZH"
-              totalTaxValue="162750.00"
-              totalGrossRevenueA="4800.00"
+              totalTaxValue="162750"
+              totalGrossRevenueA="4800"
               totalGrossRevenueB="548.29"
-              totalWithHoldingTaxClaim="1680.00"
+              totalWithHoldingTaxClaim="1680"
               minorVersion="22">
   <institution name="Sample Foreign Bank ltd">
     <uid>
@@ -22,28 +22,28 @@
     </uid>
   </institution>
   <client clientNumber="987654" salutation="2" firstName="Max" lastName="Muster"/>
-  <listOfBankAccounts totalTaxValue="35000.00" totalGrossRevenueA="0.00" totalGrossRevenueB="548.29" totalWithHoldingTaxClaim="0.00">
-    <bankAccount bankAccountName="Private Account" bankAccountCountry="LU" bankAccountCurrency="CHF" totalTaxValue="35000.00" totalGrossRevenueA="0.00" totalGrossRevenueB="548.29" totalWithHoldingTaxClaim="0.00" iban="LU9300762011623852957" bankAccountNumber="11623852957">
-      <taxValue referenceDate="2024-12-31" balanceCurrency="CHF" balance="35000.00" value="35000.00"/>
-      <payment paymentDate="2024-06-30" name="Interest Credit" amountCurrency="CHF" amount="500.00" grossRevenueA="0.00" grossRevenueB="500.00" withHoldingTaxClaim="0.00"/>
-      <payment paymentDate="2024-03-15" name="Foreign Interest" amountCurrency="EUR" amount="50.00" exchangeRate="0.9657075" grossRevenueA="0.00" grossRevenueB="48.285375000" withHoldingTaxClaim="0.00"/>
+  <listOfBankAccounts totalTaxValue="35000" totalGrossRevenueA="0" totalGrossRevenueB="548.29" totalWithHoldingTaxClaim="0">
+    <bankAccount bankAccountName="Private Account" bankAccountCountry="LU" bankAccountCurrency="CHF" totalTaxValue="35000" totalGrossRevenueA="0" totalGrossRevenueB="548.29" totalWithHoldingTaxClaim="0" iban="LU9300762011623852957" bankAccountNumber="11623852957">
+      <taxValue referenceDate="2024-12-31" balanceCurrency="CHF" balance="35000" value="35000"/>
+      <payment paymentDate="2024-06-30" name="Interest Credit" amountCurrency="CHF" amount="500" grossRevenueA="0" grossRevenueB="500" withHoldingTaxClaim="0"/>
+      <payment paymentDate="2024-03-15" name="Foreign Interest" amountCurrency="EUR" amount="50" exchangeRate="0.9657075" grossRevenueA="0" grossRevenueB="48.285375" withHoldingTaxClaim="0"/>
     </bankAccount>
   </listOfBankAccounts>
-  <listOfLiabilities totalTaxValue="250000.00" totalGrossRevenueB="3000.00">
-    <liabilityAccount bankAccountName="Mortgage Property ZH" bankAccountCountry="CH" bankAccountCurrency="CHF" totalTaxValue="250000.00" totalGrossRevenueB="3000.00" bankAccountNumber="HYPO-123">
-      <taxValue referenceDate="2024-12-31" balanceCurrency="CHF" balance="250000.00" value="250000.00"/>
-      <payment paymentDate="2024-12-31" name="Mortgage Interest Paid" amountCurrency="CHF" amount="3000.00" grossRevenueB="3000.00"/>
+  <listOfLiabilities totalTaxValue="250000" totalGrossRevenueB="3000">
+    <liabilityAccount bankAccountName="Mortgage Property ZH" bankAccountCountry="CH" bankAccountCurrency="CHF" totalTaxValue="250000" totalGrossRevenueB="3000" bankAccountNumber="HYPO-123">
+      <taxValue referenceDate="2024-12-31" balanceCurrency="CHF" balance="250000" value="250000"/>
+      <payment paymentDate="2024-12-31" name="Mortgage Interest Paid" amountCurrency="CHF" amount="3000" grossRevenueB="3000"/>
     </liabilityAccount>
   </listOfLiabilities>
-  <listOfExpenses totalExpenses="150.00">
-    <expense name="Depot Fees 2024" amountCurrency="CHF" expenses="150.00" expenseType="22" depotNumber="DEPOT-001"/>
+  <listOfExpenses totalExpenses="150">
+    <expense name="Depot Fees 2024" amountCurrency="CHF" expenses="150" expenseType="22" depotNumber="DEPOT-001"/>
   </listOfExpenses>
-  <listOfSecurities totalTaxValue="127750.00" totalGrossRevenueA="4800.00" totalGrossRevenueB="0.00" totalWithHoldingTaxClaim="1680.00" totalLumpSumTaxCredit="0.00" totalNonRecoverableTax="0.00" totalAdditionalWithHoldingTaxUSA="0.00" totalGrossRevenueIUP="0.00" totalGrossRevenueConversion="0.00">
+  <listOfSecurities totalTaxValue="127750" totalGrossRevenueA="4800" totalGrossRevenueB="0" totalWithHoldingTaxClaim="1680" totalLumpSumTaxCredit="0" totalNonRecoverableTax="0" totalAdditionalWithHoldingTaxUSA="0" totalGrossRevenueIUP="0" totalGrossRevenueConversion="0">
     <depot depotNumber="DEPOT-001">
       <security positionId="1" country="CH" currency="CHF" quotationType="PIECE" securityCategory="SHARE" securityName="Roche Holding Genussschein" valorNumber="1203204" isin="CH0012032048">
-        <taxValue referenceDate="2024-12-31" quotationType="PIECE" quantity="500" balanceCurrency="CHF" unitPrice="255.50" value="127750.00" kursliste="1"/>
-        <payment paymentDate="2024-03-18" exDate="2024-03-14" name="Dividend" quotationType="PIECE" quantity="500" amountCurrency="CHF" amountPerUnit="9.6" amount="4800.00" exchangeRate="1" grossRevenueA="4800.00" grossRevenueB="0.00" withHoldingTaxClaim="1680.00" kursliste="1"/>
-        <stock referenceDate="2024-01-01" mutation="0" quotationType="PIECE" quantity="500" balanceCurrency="CHF" value="145000.00"/>
+        <taxValue referenceDate="2024-12-31" quotationType="PIECE" quantity="500" balanceCurrency="CHF" unitPrice="255.5" value="127750" kursliste="1"/>
+        <payment paymentDate="2024-03-18" exDate="2024-03-14" name="Dividend" quotationType="PIECE" quantity="500" amountCurrency="CHF" amountPerUnit="9.6" amount="4800" exchangeRate="1" grossRevenueA="4800" grossRevenueB="0" withHoldingTaxClaim="1680" kursliste="1"/>
+        <stock referenceDate="2024-01-01" mutation="0" quotationType="PIECE" quantity="500" balanceCurrency="CHF" value="145000"/>
       </security>
     </depot>
   </listOfSecurities>

--- a/tests/utils/xml.py
+++ b/tests/utils/xml.py
@@ -1,6 +1,35 @@
 from lxml import etree as ET
 import re
-from typing import Union
+from decimal import Decimal, InvalidOperation
+
+
+_DECIMAL_LEXEME_RE = re.compile(r"^[+-]?(?:\d+\.\d*|\.\d+)$")
+
+
+def _normalize_decimal_lexeme(value: str) -> str:
+    """Normalize decimal lexical forms like 1.20/.30 to 1.2/0.3 for robust XML comparisons."""
+    if not _DECIMAL_LEXEME_RE.match(value):
+        return value
+    try:
+        return format(Decimal(value).normalize(), "f")
+    except (InvalidOperation, ValueError):
+        return value
+
+
+def _normalize_decimal_values(element: ET._Element) -> None:
+    """Normalize decimal-looking attribute and text values recursively."""
+    for attr_name, attr_value in list(element.attrib.items()):
+        element.attrib[attr_name] = _normalize_decimal_lexeme(attr_value)
+
+    if element.text:
+        stripped = element.text.strip()
+        if stripped:
+            normalized = _normalize_decimal_lexeme(stripped)
+            if normalized != stripped:
+                element.text = normalized
+
+    for child in element:
+        _normalize_decimal_values(child)
 
 def normalize_xml(xml_bytes: bytes, remove_xmlns: bool = False) -> str:
     """Normalize XML string by parsing and re-serializing it.
@@ -16,9 +45,9 @@ def normalize_xml(xml_bytes: bytes, remove_xmlns: bool = False) -> str:
     
     # Re-parse and pretty print
     tree = ET.fromstring(normalized_bytes, parser=parser) 
+    _normalize_decimal_values(tree)
     normalized = ET.tostring(tree, pretty_print=True).decode().replace('=".', '="0.')  # type: ignore
     if remove_xmlns:
-        import re
         # Remove xmlns declarations
         normalized = re.sub(r'\s+xmlns(?::[^=]*)?="[^"]*"', '', normalized)
         # Remove schemaLocation and noNamespaceSchemaLocation attributes


### PR DESCRIPTION
This re-applies #144, with a test-addition which works for round trip tests where the input XML contains non-normalized decimals.

Resolves #176