### PR TITLE
Add Docker support for simplified usage and setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,24 @@ For more information on required due diligence see the the user guide.
 
 After installing, see the [User Guide](docs/user_guide.md) for preparation steps, how to get broker data and run the command.
 
+#### Easy usage with Docker
+
+Instead of installing python and the dependencies, you can install [Docker](https://docs.docker.com/engine/install/). It makes the usage much easier and requires minimal knowledge of programming languages and their ecosystem.
+
+After installing Docker, go into the ``./docker`` directory in this project within your terminal, optionally create a config.toml file (check [User Guide](docs/user_guide.md) if you need one) and put it into the `./docker/data/` directory. Create the directory if it doesn't exist.
+
+Now generate the data from your broker. Check the usage guide for details. Rename the xml file to ``input.xml`` and put it into the `./docker/data/` directory. Now you should have the following files in the `./docker/data/` directory.
+
+Open the ``./docker/docker-compose.yml`` file (or ``docker-compose.yml`` once you are in the ``./docker`` directory) and configure it to your needs. Adjust the year, change the importer if you need to, and optionally pass some additional arguments to the tool.
+
+Now run the following command in your terminal within the ``./docker`` directory to start the docker container and generate the PDF:
+
+```bash
+docker compose up --build
+```
+
+The PDF will be generated in the `./docker/data/` directory and will be named ``tax_statement_<YEAR>.pdf``.
+
 ### Verifying an Existing Steuerauszug
 
 The tool can also be used to cross check and existing existing Steuerauszug (eCH-0196 XML). See See [verify instructions](docs/verify_existing.md).
@@ -151,7 +169,7 @@ This project includes utility scripts for development and data management. For d
 
 ### Code quality and AI usage.
 
-This project exists in part for me to try out AI based coding outside of $WORKPLACE to try out various tools. As a result code quality and style is inconsistent and contains various AIisms. Code has been cleaned-up, reviewed and controlled by me where it matters.
+This project exists in part for me to try out AI based coding outside of $WORKPLACE to try out various tools. As a result code quality and style is inconsistent and contains various AIisms. Code has been cleaned-up, reviewed, and controlled by me where it matters.
 
 That said all mistakes, hallucinations etc are probably mine.
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.14
+
+RUN apt-get update && apt-get install -y git && \
+    pip install --upgrade pip
+
+RUN git clone https://github.com/vroonhof/opensteuerauszug.git
+
+WORKDIR /opensteuerauszug
+
+RUN python3 -m venv .venv && \
+    .venv/bin/pip install .[dev] && \
+    .venv/bin/pip install git+https://github.com/vroonhof/pdf417-py.git
+
+RUN mkdir -p /data
+
+ARG YEAR=2024
+ENV YEAR=${YEAR}
+ENV IMPORTER=ibkr
+
+RUN .venv/bin/opensteuerauszug kursliste download --year ${YEAR}
+
+ENV EXTRA_ARGS=""
+
+CMD ["/bin/sh", "-c", ".venv/bin/opensteuerauszug process --importer ${IMPORTER} /data/input.xml --config /data/config.toml --output /data/tax_statement_${YEAR}.pdf --period-from ${YEAR}-01-01 --period-to ${YEAR}-12-31  \"${EXTRA_ARGS}\""]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  opensteuerauszug:
+    build:
+      context: .
+      args:
+        - YEAR=2025
+    volumes:
+      - ./data:/data
+    environment:
+      IMPORTER: ibkr
+      EXTRA_ARGS: ""


### PR DESCRIPTION
First of all, thank you for creating this.

I'm not gonna lie, but the setup was kind of a PITA and I'm a Software Engineer. There is just so much documentation which often also seems useless for most people (end users) and its gets very confusing. Also some commands in the documentation aren't working/are missing arguments. Like, I had to add the date cli arguments when using the tool for IBKR, which were missing in the docs. So the overall experience wasn't as smooth as it could be (The first time I tried using this I actually gave up, thought I would just use datalevel for this year, but I gave it another shot).

Therefore, I added a very simple docker setup which allows everyone to run this tool without struggling and installing a whole development environment. For now I can only confirm that this works for IBKR. The docker files may have to be adjusted for proper support for other brokers.

I would also advise you to aim to enhance the docker setup instead of how it currently works and make this the primary way of running this tool. For end users it makes everything just so much easier. From configuration to execution as well as removal of everything at the end and updating for the next years tax period. No need to store anything on the OS level like the kursliste. Just delete the docker volume and that's it.

For now this is a basic docker setup but I might contribute more to it when your approve the overall switch to it.