### PR TITLE
PDF: Slightly adjust bank account column widths

### DIFF
--- a/src/opensteuerauszug/render/render.py
+++ b/src/opensteuerauszug/render/render.py
@@ -874,6 +874,7 @@ def create_liabilities_table(tax_statement, styles, usable_width):
     ])
 
     col_widths = [24*mm, 110*mm, 19*mm, 28*mm, 18*mm, 28*mm, 5*mm, 8, 23*mm]
+    assert sum(col_widths) < usable_width
     liabilities_table = Table(table_data, colWidths=col_widths)
 
     table_style = [
@@ -1530,7 +1531,8 @@ def create_bank_accounts_table(tax_statement, styles, usable_width):
     ])
 
     # Column widths (adjust as needed for layout)
-    col_widths = [24*mm, 80*mm, 18*mm, 28*mm, 18*mm, 28*mm, 5*mm, 8, 23*mm, 5*mm,  8 , 23*mm]
+    col_widths = [24*mm, 94*mm, 16*mm, 20*mm, 18*mm, 24*mm, 5*mm, 8, 23*mm, 5*mm,  8 , 23*mm]
+    assert sum(col_widths) < usable_width
     bank_table = Table(table_data, colWidths=col_widths)
     # --- Table style for header and intermediate totals ---
     table_style = [

--- a/tests/render/test_render.py
+++ b/tests/render/test_render.py
@@ -355,7 +355,7 @@ def test_integration_render_all_samples(mock_render_to_barcodes, sample_file):
 def test_create_bank_accounts_table_none():
     styles = getSampleStyleSheet()
     tax_statement = TaxStatement(minorVersion=2)
-    result = create_bank_accounts_table(tax_statement, styles, 500)
+    result = create_bank_accounts_table(tax_statement, styles, 737)
     assert result is None
 
 def test_create_bank_accounts_table_single_minimal():
@@ -387,7 +387,7 @@ def test_create_bank_accounts_table_single_minimal():
             totalGrossRevenueB=Decimal("5.00")
         )
     )
-    table = create_bank_accounts_table(tax_statement, styles, 500)
+    table = create_bank_accounts_table(tax_statement, styles, 737)
     assert isinstance(table, Table)
     # Should have at least header + 2 rows (label, value)
     assert len(table._cellvalues) >= 3  # type: ignore[attr-defined]
@@ -451,7 +451,7 @@ def test_create_bank_accounts_table_multiple_accounts_with_payments():
             totalGrossRevenueB=Decimal("0.00")
         )
     )
-    table = create_bank_accounts_table(tax_statement, styles, 500)
+    table = create_bank_accounts_table(tax_statement, styles, 737)
     assert isinstance(table, Table)
     # Should have header + rows for each account and payment
     assert len(table._cellvalues) > 4  # type: ignore[attr-defined]
@@ -491,7 +491,7 @@ def test_create_bank_accounts_table_with_opening_date():
             totalGrossRevenueB=Decimal("0"),
         ),
     )
-    table = create_bank_accounts_table(tax_statement, styles, 500)
+    table = create_bank_accounts_table(tax_statement, styles, 737)
     assert isinstance(table, Table)
     # Find the account description cell and check for opening date text
     all_text = " ".join(
@@ -529,7 +529,7 @@ def test_create_bank_accounts_table_with_closing_date():
             totalGrossRevenueB=Decimal("0"),
         ),
     )
-    table = create_bank_accounts_table(tax_statement, styles, 500)
+    table = create_bank_accounts_table(tax_statement, styles, 737)
     assert isinstance(table, Table)
     all_text = " ".join(
         cell.text for row in table._cellvalues for cell in row if isinstance(cell, Paragraph)
@@ -567,7 +567,7 @@ def test_create_bank_accounts_table_with_both_dates():
             totalGrossRevenueB=Decimal("0"),
         ),
     )
-    table = create_bank_accounts_table(tax_statement, styles, 500)
+    table = create_bank_accounts_table(tax_statement, styles, 737)
     assert isinstance(table, Table)
     all_text = " ".join(
         cell.text for row in table._cellvalues for cell in row if isinstance(cell, Paragraph)
@@ -606,7 +606,7 @@ def test_create_bank_accounts_table_without_dates():
             totalGrossRevenueB=Decimal("0"),
         ),
     )
-    table = create_bank_accounts_table(tax_statement, styles, 500)
+    table = create_bank_accounts_table(tax_statement, styles, 737)
     assert isinstance(table, Table)
     all_text = " ".join(
         cell.text for row in table._cellvalues for cell in row if isinstance(cell, Paragraph)


### PR DESCRIPTION
This is needed for previnging line breaks when name is longer.
Example: `USD IBKR MANAGED SECURITIES (SYEP) INTEREST FOR MAR-2025`