### PR TITLE
Add option to use pixi instead of venv for dev work

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ uv run --with git+https://github.com/vroonhof/opensteuerauszug.git opensteueraus
 
 Then continue with the [User Guide](docs/user_guide.md).
 
-### Development install [option 1] (contributors)
+### Development install [option 1] (contributors: using python venv)
 
 For development and tests, install from source:
 
@@ -134,7 +134,7 @@ For detailed documentation on available scripts, including the Kursliste filteri
 
 ### Setup
 
-To set up the development environment:
+To set up the development environment (venv):
 
 ```bash
 # Create and activate virtual environment
@@ -144,6 +144,16 @@ source venv/bin/activate  # On Windows: venv\Scripts\activate
 # Install dependencies
 pip install -e ".[dev]"
 pip install git+https://github.com/vroonhof/pdf417decoder.git#subdirectory=python
+```
+
+To set up the development environment (pixi):
+
+```bash
+. ./setup_pixi.sh
+```
+or (in the installation directory)
+```bash
+pixi shell
 ```
 
 ### Testing

--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ pip install git+https://github.com/vroonhof/pdf417decoder.git#subdirectory=pytho
 git clone https://github.com/vroonhof/opensteuerauszug.git
 cd opensteuerauszug
 . ./scripts/setup_pixi.sh
+```
+
 ### Verifying the generated XML
 
 When you export the final XML using `--xml-output`, you can validate it

--- a/README.md
+++ b/README.md
@@ -75,32 +75,8 @@ The [EWV](https://www.ewv-ete.ch/de/ewv-ete/) and SSK publish a [shared set of t
 # One-time install of the CLI via uv
 ```console 
 uv tool install --from git+https://github.com/vroonhof/opensteuerauszug.git opensteuerauszug
-```
-# install of the CLI using pixi (https://pixi.prefix.dev/latest/)
-in the directory you want to use for installation:
-```console 
-git clone https://github.com/vroonhof/opensteuerauszug.git .
-```
-then (if linux or macos):
-```console 
-cd opensteuerauszug
-. ./scripts/setup_pixi.sh
-```
-or (after installing pixi):
-```console 
-cd opensteuerauszug
-pixi init -i requirements.yaml
-pixi add --pypi --editable "opensteuerauszug @ file:$PWD"
-```
 
 # Then run normally (without pixi, or after . ./scripts/setup_pixi.sh)
-```console 
-opensteuerauszug --help
-```
-or:
-
-```console
-pixi shell
 opensteuerauszug --help
 ```
 
@@ -117,7 +93,7 @@ uv run --with git+https://github.com/vroonhof/opensteuerauszug.git opensteueraus
 
 Then continue with the [User Guide](docs/user_guide.md).
 
-### Development install (contributors)
+### Development install [option 1] (contributors)
 
 For development and tests, install from source:
 
@@ -129,7 +105,11 @@ source .venv/bin/activate  # On Windows: .venv\Scripts\activate
 pip install -e ".[dev]"
 pip install git+https://github.com/vroonhof/pdf417decoder.git#subdirectory=python
 ```
-
+### Development install [option 2] (contributors: using [pixi](https://pixi.prefix.dev/latest/))
+```console
+git clone https://github.com/vroonhof/opensteuerauszug.git
+cd opensteuerauszug
+. ./scripts/setup_pixi.sh
 ### Verifying the generated XML
 
 When you export the final XML using `--xml-output`, you can validate it

--- a/README.md
+++ b/README.md
@@ -143,17 +143,12 @@ source venv/bin/activate  # On Windows: venv\Scripts\activate
 
 # Install dependencies
 pip install -e ".[dev]"
-pip install git+https://github.com/vroonhof/pdf417decoder.git#subdirectory=python
 ```
 
 To set up the development environment (pixi):
 
 ```bash
 . ./setup_pixi.sh
-```
-or (in the installation directory)
-```bash
-pixi shell
 ```
 
 ### Testing

--- a/README.md
+++ b/README.md
@@ -71,11 +71,36 @@ The [EWV](https://www.ewv-ete.ch/de/ewv-ete/) and SSK publish a [shared set of t
 
 ### Quick install (recommended for users)
 
-```console
-# One-time install of the CLI via uv
-uv tool install --from git+https://github.com/vroonhof/opensteuerauszug.git opensteuerauszug
 
-# Then run normally
+# One-time install of the CLI via uv
+```console 
+uv tool install --from git+https://github.com/vroonhof/opensteuerauszug.git opensteuerauszug
+```
+# install of the CLI using pixi (https://pixi.prefix.dev/latest/)
+in the directory you want to use for installation:
+```console 
+git clone https://github.com/vroonhof/opensteuerauszug.git .
+```
+then (if linux or macos):
+```console 
+cd opensteuerauszug
+. ./scripts/setup_pixi.sh
+```
+or (after installing pixi):
+```console 
+cd opensteuerauszug
+pixi init -i requirements.yaml
+pixi add --pypi "opensteuerauszug @ file:$PWD"
+```
+
+# Then run normally (without pixi, or after . ./scripts/setup_pixi.sh)
+```console 
+opensteuerauszug --help
+```
+or:
+
+```console
+pixi shell
 opensteuerauszug --help
 ```
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ or (after installing pixi):
 ```console 
 cd opensteuerauszug
 pixi init -i requirements.yaml
-pixi add --pypi "opensteuerauszug @ file:$PWD"
+pixi add --pypi --editable "opensteuerauszug @ file:$PWD"
 ```
 
 # Then run normally (without pixi, or after . ./scripts/setup_pixi.sh)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,8 +49,7 @@ dev = [
     "flake8>=6.0.0",
     "Flake8-pyproject",
     "freezegun>=1.5.0",
-    # TODO make these formal dependencies
-    # pip install git+https://github.com/vroonhof/pdf417decoder.git#subdirectory=python
+    "pdf417decoder @ git+https://github.com/vroonhof/pdf417decoder.git#subdirectory=python" 
 ]
 
 [tool.black]

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -1,0 +1,6 @@
+name: background_estimate
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -1,6 +1,0 @@
-name: background_estimate
-channels:
-  - conda-forge
-  - defaults
-dependencies:
-  - python

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -106,26 +106,13 @@ setup opensteuerauszug pixi environment
 . ./scripts/setup_pixi.sh
 ```
 
-when presented with the option
-```console
-A 'pyproject.toml' file already exists. Do you want to extend it with the '[tool.pixi]' configuration?
-```
-choose yes.
-Otherwise run
-```console
-pixi add "python >= {version}"
-```
-and try
-
-```bash
-. ./scripts/setup_pixi.sh
-```
-
-again
 This will:
 - (If needed) Initialise the pixi environment 'opensteuerauszug'
 - (If needed) Install the required packages from the requirements.yaml file
+- (If needed) Create the opensteuerauszug pixi workspace
 - (If needed) Install opensteuerauszug as an editable pypi package
+- (If needed) Create the opensteuerauszug dev pixi environment 
+- (If needed) Install opensteuerauszug[dev] an editable pypi package in the dev environment
 - launch the pixi dev environment for opensteuerauszug
 
 **Safety note:** this repository is public. By default the script does not upload artifacts or

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -96,6 +96,10 @@ setup opensteuerauszug pixi environment
 * `pixi` available in PATH
 * macos or linux (zsh,bash,csh,tcsh shells)
 
+**Command-Line Arguments:**
+
+* `-b` : (Optional) Do not immediately activate the pixi environment after setup.
+
 **Usage Example:**
 
 ```bash

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -88,6 +88,26 @@ This will:
 - Store logs and optional result paths under `local-action-results/<run-id>/`.
 - Only upload artifacts and create a check run when `--upload-artifacts` and `--confirm-upload` are set.
 
+### pixi setup script (`scripts/setup_pixi.sh`)
+
+setup opensteuerauszug pixi environment
+
+**Requirements:**
+* `pixi` available in PATH
+* macos or linux (zsh,bash,csh,tcsh shells)
+
+**Usage Example:**
+
+```bash
+. ./scripts/setup_pixi.sh
+```
+
+This will:
+- Initialise the pixi environment 'opensteuerauszug'
+- Install the required packages from the requirements.yaml file
+- Install opensteuerauszug as an editable pypi package
+
+
 **Safety note:** this repository is public. By default the script does not upload artifacts or
 create a check run. When you opt in to `--confirm-upload` without `--upload-artifacts`, only the
 stderr text is sent to the check run summary. Only opt in after reviewing outputs and confirming

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -108,11 +108,8 @@ setup opensteuerauszug pixi environment
 
 This will:
 - (If needed) Initialise the pixi environment 'opensteuerauszug'
-- (If needed) Install the required packages from the requirements.yaml file
 - (If needed) Create the opensteuerauszug pixi workspace
-- (If needed) Install opensteuerauszug as an editable pypi package
-- (If needed) Create the opensteuerauszug dev pixi environment 
-- (If needed) Install opensteuerauszug[dev] an editable pypi package in the dev environment
+- (If needed) Install opensteuerauszug[dev] an editable pypi package in workspace 
 - launch the pixi dev environment for opensteuerauszug
 
 **Safety note:** this repository is public. By default the script does not upload artifacts or

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -106,11 +106,27 @@ setup opensteuerauszug pixi environment
 . ./scripts/setup_pixi.sh
 ```
 
-This will:
-- Initialise the pixi environment 'opensteuerauszug'
-- Install the required packages from the requirements.yaml file
-- Install opensteuerauszug as an editable pypi package
+when presented with the option
+```console
+A 'pyproject.toml' file already exists. Do you want to extend it with the '[tool.pixi]' configuration?
+```
+choose yes.
+Otherwise run
+```console
+pixi add "python >= {version}"
+```
+and try
 
+```bash
+. ./scripts/setup_pixi.sh
+```
+
+again
+This will:
+- (If needed) Initialise the pixi environment 'opensteuerauszug'
+- (If needed) Install the required packages from the requirements.yaml file
+- (If needed) Install opensteuerauszug as an editable pypi package
+- launch the pixi dev environment for opensteuerauszug
 
 **Safety note:** this repository is public. By default the script does not upload artifacts or
 create a check run. When you opt in to `--confirm-upload` without `--upload-artifacts`, only the

--- a/scripts/setup_pixi.sh
+++ b/scripts/setup_pixi.sh
@@ -40,7 +40,7 @@ if ! pixi info | grep -q "Name: $PIXI_ENV_NAME"; then
   # create pixi workspace 
   printf -- "--> pixi environment '$PIXI_ENV_NAME' not found\n"
   printf -- "--> Creating new pixi workspace: $PIXI_ENV_NAME\n"
-  pixi init -i requirements.yaml
+  pixi init
   printf -- "--> adding framework as pypi package\n"
   pixi add --pypi --editable "$PIXI_ENV_NAME @ file:$PWD"
   pixi add --pypi "pdf417decoder @ git+https://github.com/vroonhof/pdf417decoder.git#subdirectory=python"

--- a/scripts/setup_pixi.sh
+++ b/scripts/setup_pixi.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# define conda environment name
+PIXI_ENV_NAME=opensteuerauszug
+
+# check if the pixi command exists
+PIXI_INSTALLED=false
+if command -v pixi &> /dev/null; then
+  PIXI_INSTALLED=true
+fi
+
+# check if pixi is already installed
+if [[ "$PIXI_INSTALLED" = false ]]; then
+  printf "No installed pixi found!\n"
+  printf -- "--> Installing pixi ..\n\n"
+  # installation for macOS or linux 
+  if [[ $OSTYPE == 'darwin'* || $OSTYPE == 'linux'* ]]; then
+    curl -fsSL https://pixi.sh/install.sh | sh
+    if [ -n "$BASH_VERSION" ]; then
+      printf -- "--> sourcing ~/.bashrc\n\n"
+      source ~/.bashrc
+    elif [ -n "$ZSH_VERSION" ]; then
+      printf -- "--> sourcing ~/.zshrc\n\n"
+      source ~/.zshrc
+    elif [ -n "$tcsh" ] || [ -n "$csh" ]; then
+      printf -- "--> sourcing ~/.cshrc\n\n"
+      source ~/.cshrc
+    fi
+  # installation for linux
+  # other operating system not supported
+  else
+    echo "Operating system not supported. Setup not possible."
+    return 1 # exit will kill bash after sourcing, use return
+  fi
+else
+  printf -- "--> pixi found.\n\n"
+fi
+
+# check if pixi workspace exists
+if ! pixi info | grep -q "Name: $PIXI_ENV_NAME"; then
+  # create pixi workspace 
+  printf -- "--> pixi environment '$PIXI_ENV_NAME' not found\n"
+  printf -- "--> Creating new pixi workspace: $PIXI_ENV_NAME\n"
+  pixi init -i requirements.yaml
+  printf -- "--> adding framework as pypi package\n"
+  pixi add --pypi --editable "$PIXI_ENV_NAME @ file:$PWD"
+  printf -- "--> framework added\n"
+else
+  printf --  "--> pixi workspace $PIXI_ENV_NAME found\n\n"
+fi
+# activate pixi 
+
+if [ $# -eq 0 ]; then 
+  printf -- "--> Activating pixi environment\n"
+  pixi shell
+elif [ "$1" == "-b" ]; then
+  printf -- "--> Not Activating pixi environment\n"
+else
+  printf -- "--> Activating pixi environment\n"
+  pixi shell
+fi

--- a/scripts/setup_pixi.sh
+++ b/scripts/setup_pixi.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
-# define conda environment name
-PIXI_ENV_NAME=opensteuerauszug
 
 # check if the pixi command exists
 PIXI_INSTALLED=false
@@ -21,9 +19,14 @@ if ! pixi info | grep -q "Name: $PIXI_ENV_NAME"; then
   # create pixi workspace 
   printf -- "--> pixi environment '$PIXI_ENV_NAME' not found\n"
   printf -- "--> Creating new pixi workspace: $PIXI_ENV_NAME\n"
-  pixi init
-  pixi add --pypi --editable "$PIXI_ENV_NAME @ file:$PWD"
-  printf -- "--> framework added\n"
+  pixi init ../opensteuerauszug
+  if !  pixi info  | grep -q "Environment: dev"; then
+    pixi add python
+    pixi add --pypi --editable "opensteuerauszug @ file:$PWD"
+    pixi add --pypi --feature dev --editable "opensteuerauszug[dev] @ file:$PWD"
+    pixi workspace environment add dev --feature dev
+  fi
+  printf -- "--> workspace opensteuerauszug added\n"
 else
   printf --  "--> pixi workspace $PIXI_ENV_NAME found\n\n"
 fi

--- a/scripts/setup_pixi.sh
+++ b/scripts/setup_pixi.sh
@@ -15,29 +15,25 @@ else
 fi
 
 # check if pixi workspace exists
-if ! pixi info | grep -q "Name: $PIXI_ENV_NAME"; then
+if ! pixi info | grep -q "Name: opensteuerauszug"; then
   # create pixi workspace 
-  printf -- "--> pixi environment '$PIXI_ENV_NAME' not found\n"
-  printf -- "--> Creating new pixi workspace: $PIXI_ENV_NAME\n"
-  pixi init ../opensteuerauszug
-  if !  pixi info  | grep -q "Environment: dev"; then
-    pixi add python
-    pixi add --pypi --editable "opensteuerauszug @ file:$PWD"
-    pixi add --pypi --feature dev --editable "opensteuerauszug[dev] @ file:$PWD"
-    pixi workspace environment add dev --feature dev
-  fi
+  printf -- "--> pixi workspace 'opensteuerauszug' not found\n"
+  printf -- "--> Creating new pixi workspace: opensteuerauszug\n"
+  pixi init --format pixi ../opensteuerauszug
+  pixi add python
+  pixi add --pypi --editable "opensteuerauszug[dev] @ file:$PWD"
   printf -- "--> workspace opensteuerauszug added\n"
 else
-  printf --  "--> pixi workspace $PIXI_ENV_NAME found\n\n"
+  printf --  "--> pixi workspace opensteuerauszug found\n\n"
 fi
 # activate pixi 
 
 if [ $# -eq 0 ]; then 
-  printf -- "--> Activating pixi dev environment\n"
-  pixi shell -e dev
+  printf -- "--> Activating pixi environment\n"
+  pixi shell
 elif [ "$1" == "-b" ]; then
   printf -- "--> Not Activating pixi environment\n"
 else
-  printf -- "--> Activating pixi dev environment\n"
-  pixi shell -e dev
+  printf -- "--> Activating pixi environment\n"
+  pixi shell
 fi

--- a/scripts/setup_pixi.sh
+++ b/scripts/setup_pixi.sh
@@ -10,27 +10,8 @@ fi
 
 # check if pixi is already installed
 if [[ "$PIXI_INSTALLED" = false ]]; then
-  printf "No installed pixi found!\n"
-  printf -- "--> Installing pixi ..\n\n"
-  # installation for macOS or linux 
-  if [[ $OSTYPE == 'darwin'* || $OSTYPE == 'linux'* ]]; then
-    curl -fsSL https://pixi.sh/install.sh | sh
-    if [ -n "$BASH_VERSION" ]; then
-      printf -- "--> sourcing ~/.bashrc\n\n"
-      source ~/.bashrc
-    elif [ -n "$ZSH_VERSION" ]; then
-      printf -- "--> sourcing ~/.zshrc\n\n"
-      source ~/.zshrc
-    elif [ -n "$tcsh" ] || [ -n "$csh" ]; then
-      printf -- "--> sourcing ~/.cshrc\n\n"
-      source ~/.cshrc
-    fi
-  # installation for linux
-  # other operating system not supported
-  else
     echo "Operating system not supported. Setup not possible."
     return 1 # exit will kill bash after sourcing, use return
-  fi
 else
   printf -- "--> pixi found.\n\n"
 fi
@@ -41,9 +22,7 @@ if ! pixi info | grep -q "Name: $PIXI_ENV_NAME"; then
   printf -- "--> pixi environment '$PIXI_ENV_NAME' not found\n"
   printf -- "--> Creating new pixi workspace: $PIXI_ENV_NAME\n"
   pixi init
-  printf -- "--> adding framework as pypi package\n"
   pixi add --pypi --editable "$PIXI_ENV_NAME @ file:$PWD"
-  pixi add --pypi "pdf417decoder @ git+https://github.com/vroonhof/pdf417decoder.git#subdirectory=python"
   printf -- "--> framework added\n"
 else
   printf --  "--> pixi workspace $PIXI_ENV_NAME found\n\n"
@@ -51,11 +30,11 @@ fi
 # activate pixi 
 
 if [ $# -eq 0 ]; then 
-  printf -- "--> Activating pixi environment\n"
-  pixi shell
+  printf -- "--> Activating pixi dev environment\n"
+  pixi shell -e dev
 elif [ "$1" == "-b" ]; then
   printf -- "--> Not Activating pixi environment\n"
 else
-  printf -- "--> Activating pixi environment\n"
-  pixi shell
+  printf -- "--> Activating pixi dev environment\n"
+  pixi shell -e dev
 fi

--- a/scripts/setup_pixi.sh
+++ b/scripts/setup_pixi.sh
@@ -43,6 +43,7 @@ if ! pixi info | grep -q "Name: $PIXI_ENV_NAME"; then
   pixi init -i requirements.yaml
   printf -- "--> adding framework as pypi package\n"
   pixi add --pypi --editable "$PIXI_ENV_NAME @ file:$PWD"
+  pixi add --pypi "pdf417decoder @ git+https://github.com/vroonhof/pdf417decoder.git#subdirectory=python"
   printf -- "--> framework added\n"
 else
   printf --  "--> pixi workspace $PIXI_ENV_NAME found\n\n"


### PR DESCRIPTION
This adds an option which shouldn't cause any problems. (using pixi instead of venv)
My commits are a bit messy, sorry about that.
This is just to make it easier for me to add another broker (Fidelity Investments) and maybe for others to contribute