### PR TITLE
Support Schwab `Journaled Shares` transactions

### DIFF
--- a/src/opensteuerauszug/importers/schwab/transaction_extractor.py
+++ b/src/opensteuerauszug/importers/schwab/transaction_extractor.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 # Known actions from formats.md
 KNOWN_ACTIONS = {
     "Buy", "Cash In Lieu", "Credit Interest", "Deposit", "Dividend", "Journal",
+    "Journaled Shares",
     "NRA Tax Adj", "Reinvest Dividend", "Qual Div Reinvest", "Reinvest Shares", "Sale", "Sell", "Stock Plan Activity", "Stock Split",
     "Tax Withholding", "Transfer", "Security Transfer", "Wire Transfer"
 }
@@ -434,7 +435,7 @@ class TransactionExtractor:
                 # )
                 cash_stock = create_cash_stock(schwab_amount, f"Cash in for Cash In Lieu {pos_object.symbol if isinstance(pos_object, SecurityPosition) else 'Cash'}")
 
-        elif action == "Journal":
+        elif action == "Journal" or action == "Journaled Shares":
             if schwab_qty and pos_object.type == "security": # Security journal
                 # Assume no cash impact unless Amount/Price present and non-zero?
                 cash_flow = None
@@ -447,7 +448,7 @@ class TransactionExtractor:
                 sec_stock = SecurityStock(
                     referenceDate=tx_date, mutation=True, quotationType="PIECE",
                     quantity=schwab_qty, balanceCurrency=currency, # Use currency string
-                    name="Journal (Shares)"
+                    name=f"{action} (Shares)"
                 )
                 if cash_flow:
                      cash_stock = create_cash_stock(cash_flow, f"Cash flow for Journal {pos_object.symbol}")

--- a/tests/importers/schwab/test_transaction_extractor.py
+++ b/tests/importers/schwab/test_transaction_extractor.py
@@ -606,6 +606,32 @@ class TestSchwabTransactionExtractor:
         assert stock.name is not None
         assert stock.name == "Journal (Shares)"
 
+    def test_action_journaled_shares_security_is_supported(self):
+        extractor = create_extractor(filename_for_depot_test="Brokerage_XX742_Transactions_20250520.json")
+        data = {
+            "FromDate": "01/01/2025", "ToDate": "12/31/2025",
+            "BrokerageTransactions": [{
+                "Date": "04/30/2025", "Action": "Journaled Shares", "Symbol": "NOVN",
+                "Description": "NOVARTIS AG", "Quantity": "71.322", "Price": "$95.10", "Amount": ""
+            }]
+        }
+        result = run_extraction_test(extractor, data, 1)
+        assert result is not None
+        novn_data = find_position(result, SecurityPosition, "NOVN")
+        assert novn_data is not None
+
+        pos, stocks, payments = novn_data
+        assert isinstance(pos, SecurityPosition)
+        assert pos.depot == "742"
+        assert payments is None
+        assert len(stocks) == 1
+        stock = stocks[0]
+        assert stock.referenceDate == date(2025, 4, 30)
+        assert stock.mutation is True
+        assert stock.quantity == Decimal("71.322")
+        assert stock.name == "Journaled Shares (Shares)"
+        assert stock.unitPrice is None
+
     def test_action_journal_cash(self):
         extractor = create_extractor()
         data = {


### PR DESCRIPTION
### Motivation
- Schwab JSON exports include an action labelled `Journaled Shares` which was treated as unknown and caused a `ValueError` during import for security positions.

### Description
- Added `"Journaled Shares"` to the `KNOWN_ACTIONS` set in `TransactionExtractor` so the action is recognized. 
- Treated `Journaled Shares` the same as `Journal` for security contexts by handling it in the same branch of `_process_single_transaction`, producing a `SecurityStock` mutation for the position. 
- Preserved action-specific naming by using `name=f"{action} (Shares)"` so entries show `Journaled Shares (Shares)` for clearer traceability. 
- Added a regression test (`tests/importers/schwab/test_transaction_extractor.py`) using anonymized depot and security (`NOVN`, depot `742`) to verify the `Journaled Shares` case is parsed correctly.

### Testing
- Ran the Schwab transaction extractor unit tests with `pytest tests/importers/schwab/test_transaction_extractor.py -q` which completed successfully with `34 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc8841e414832e88da9a3253f99e96)