### PR TITLE
Refactor reconciliation comparison and restore US 2x withholding note

### DIFF
--- a/src/opensteuerauszug/calculate/payment_reconciliation_calculator.py
+++ b/src/opensteuerauszug/calculate/payment_reconciliation_calculator.py
@@ -21,6 +21,10 @@ from opensteuerauszug.model.payment_reconciliation import (
 
 logger = logging.getLogger(__name__)
 
+_CMP_LOWER = -1
+_CMP_EQUAL = 0
+_CMP_HIGHER = 1
+
 
 @dataclass
 class _BrokerAgg:
@@ -209,13 +213,13 @@ class PaymentReconciliationCalculator:
                 allow_broker_above_kursliste = (
                     kurs.allows_broker_above_kursliste or broker.allows_broker_above_kursliste
                 )
-                div_ok = self._component_matches(
+                div_cmp = self._compare_component(
                     kurs_value_chf=kurs.dividend_chf,
                     broker_value_chf=broker_div_chf,
                     allow_bidirectional_on_noncash=kurs.noncash,
                     allow_broker_above_kursliste=allow_broker_above_kursliste,
                 )
-                w_ok = self._component_matches(
+                w_cmp = self._compare_component(
                     kurs_value_chf=kurs.withholding_chf,
                     broker_value_chf=broker_with_chf,
                     allow_bidirectional_on_noncash=kurs.noncash,
@@ -223,11 +227,27 @@ class PaymentReconciliationCalculator:
                         allow_broker_above_kursliste or not security_has_sensitive_overwithholding
                     ),
                 )
-                if not div_ok:
+                if div_cmp == _CMP_LOWER:
                     note = "Broker dividend is below Kursliste value beyond tolerance."
-                elif not w_ok:
+                elif div_cmp == _CMP_HIGHER:
+                    note = "Broker dividend is above Kursliste value beyond tolerance."
+                elif w_cmp == _CMP_LOWER:
                     note = "Broker withholding is below Kursliste value beyond tolerance."
-                matched = div_ok and w_ok
+                elif w_cmp == _CMP_HIGHER:
+                    if (
+                        country == "US"
+                        and broker_with_chf is not None
+                        and kurs.withholding_chf
+                        and kurs.withholding_chf != 0
+                        and abs((broker_with_chf / kurs.withholding_chf) - 2) < Decimal("0.01")
+                    ):
+                        note = (
+                            "Broker withholding is twice Kursliste value, check that your broker "
+                            "has a valid W-8BEN/1042-S setup."
+                        )
+                    else:
+                        note = "Broker withholding is above Kursliste value beyond tolerance."
+                matched = div_cmp == _CMP_EQUAL and w_cmp == _CMP_EQUAL
                 status = "match" if matched else "mismatch"
             elif not has_kurs and has_broker:
                 note = "Broker payment has no Kursliste entry."
@@ -268,30 +288,32 @@ class PaymentReconciliationCalculator:
 
         return rows
 
-    def _component_matches(
+    def _compare_component(
         self,
         kurs_value_chf: Decimal,
         broker_value_chf: Optional[Decimal],
         allow_bidirectional_on_noncash: bool,
         allow_broker_above_kursliste: bool,
-    ) -> bool:
+    ) -> int:
         if broker_value_chf is None:
-            return abs(kurs_value_chf) < Decimal("0.01")
+            if abs(kurs_value_chf) < Decimal("0.01"):
+                return _CMP_EQUAL
+            return _CMP_LOWER
 
         if allow_bidirectional_on_noncash:
-            return True
+            return _CMP_EQUAL
 
         delta = broker_value_chf - kurs_value_chf
         if abs(delta) <= self.tolerance_chf:
-            return True
+            return _CMP_EQUAL
 
         if abs(delta) <= self.tolerance_frac * broker_value_chf:
-            return True
+            return _CMP_EQUAL
 
         if delta > self.tolerance_chf and allow_broker_above_kursliste:
-            return True
+            return _CMP_EQUAL
 
-        return False
+        return _CMP_HIGHER if delta > 0 else _CMP_LOWER
 
     def _accumulate_broker(self, agg: _BrokerAgg, payment: SecurityPayment) -> None:
         if self._is_broker_above_kursliste_allowlisted(payment):

--- a/tests/calculate/test_payment_reconciliation_calculator.py
+++ b/tests/calculate/test_payment_reconciliation_calculator.py
@@ -237,6 +237,7 @@ def test_broker_above_kursliste_without_allowlist_is_mismatch():
     result = PaymentReconciliationCalculator().calculate(statement)
     row = result.payment_reconciliation_report.rows[0]
     assert row.status == "mismatch"
+    assert row.note == "Broker dividend is above Kursliste value beyond tolerance."
 
 
 def test_per_share_fx_rounding_within_tolerance_is_match():
@@ -615,6 +616,72 @@ def test_broker_withholding_above_kursliste_is_mismatch_for_treaty_security():
     row = result.payment_reconciliation_report.rows[0]
     assert row.status == "mismatch"
     assert row.matched is False
+    assert row.note == "Broker withholding is above Kursliste value beyond tolerance."
+
+
+def test_broker_withholding_twice_kursliste_uses_w8ben_specific_note_for_us_security():
+    statement = TaxStatement(
+        minorVersion=2,
+        listOfSecurities=ListOfSecurities(
+            depot=[
+                Depot(
+                    depotNumber=DepotNumber("D1"),
+                    security=[
+                        Security(
+                            positionId=1,
+                            country="US",
+                            currency="USD",
+                            quotationType="PIECE",
+                            securityCategory="SHARE",
+                            securityName="AAPL",
+                            payment=[
+                                SecurityPayment(
+                                    paymentDate=date(2025, 12, 23),
+                                    quotationType="PIECE",
+                                    quantity=Decimal("1"),
+                                    amountCurrency="USD",
+                                    amount=Decimal("100"),
+                                    exchangeRate=Decimal("1"),
+                                    grossRevenueB=Decimal("100"),
+                                    withHoldingTaxClaim=Decimal("6"),
+                                    kursliste=True,
+                                )
+                            ],
+                            broker_payments=[
+                                SecurityPayment(
+                                    paymentDate=date(2025, 12, 23),
+                                    quotationType="PIECE",
+                                    quantity=Decimal("-1"),
+                                    amountCurrency="USD",
+                                    amount=Decimal("100"),
+                                    name="Dividend",
+                                ),
+                                SecurityPayment(
+                                    paymentDate=date(2025, 12, 23),
+                                    quotationType="PIECE",
+                                    quantity=Decimal("-1"),
+                                    amountCurrency="USD",
+                                    amount=Decimal("-12"),
+                                    name="Withholding",
+                                    nonRecoverableTaxAmountOriginal=Decimal("12"),
+                                ),
+                            ],
+                        )
+                    ],
+                )
+            ]
+        ),
+    )
+
+    result = PaymentReconciliationCalculator().calculate(statement)
+    row = result.payment_reconciliation_report.rows[0]
+    assert row.status == "mismatch"
+    assert row.matched is False
+    assert (
+        row.note
+        == "Broker withholding is twice Kursliste value, check that your broker has a valid "
+        "W-8BEN/1042-S setup."
+    )
 
 
 def test_negligible_kursliste_values_allow_missing_broker_entry():
@@ -1236,4 +1303,3 @@ def test_withholding_cap_zeros_when_broker_has_no_wht_entries():
     assert kl_payment.withholding_capped is True
     assert kl_payment.withholding_capped_original_wht_chf == Decimal("8.25")
     assert kl_payment.sign is None
-


### PR DESCRIPTION
### Motivation
- Clean up the payment-reconciliation logic by replacing a boolean match helper with a comparator so the code can explicitly detect "below/equal/above" cases and avoid recomputing the same condition twice.
- Make mismatch notes more precise (explicitly state when broker amounts are above Kursliste) and preserve the US-specific guidance when broker withholding is approximately 2× the Kursliste withholding, as requested in the review.

### Description
- Added comparator constants `_CMP_LOWER`, `_CMP_EQUAL`, `_CMP_HIGHER` and introduced `_compare_component` which returns an ordered result instead of a boolean.
- Replaced calls to the old boolean helper with `_compare_component` and use the comparator outcome to set `note`, `matched`, and `status` (including explicit "above" messages).
- Reintroduced the US-specific note: when withholding for a US security is ~2× the Kursliste withholding the note suggests checking W-8BEN/1042-S setup.
- Updated tests in `tests/calculate/test_payment_reconciliation_calculator.py` to assert the new explicit notes and added a dedicated test for the US 2× withholding note path.

### Testing
- Ran `pytest tests/calculate/test_payment_reconciliation_calculator.py -q` and all tests passed (`23 passed`).
- Ran `pytest tests/calculate/test_previous_year_exdate_warning.py -q` and all tests passed (`6 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcb2478bfc832e8089c91915643550)