### PR TITLE
Expand Schwab transaction type coverage using KapJI sample data

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,11 @@ That said all mistakes, hallucinations etc are probably mine.
 - https://github.com/stefanloerwald/zh-tax-csv-import : if you want an
   automated import that controls PrivateTax directly. It is more hacky but leaves no trace for the tax office to be confused about.
 - https://github.com/BrunoEberhard/open-ech-taxstatement : An old project I only discovered later that contains a model defintion of the Tax data targeting Java. The author has since left the Swis open data efforts.
+- https://github.com/KapJI/capital-gains-calculator : UK Capital Gains Tax calculator
+  supporting Charles Schwab, Interactive Brokers, and others. Thanks to
+  [@KapJI](https://github.com/KapJI) and contributors for the comprehensive Schwab
+  transaction type coverage and sample data that helped improve our importer. Their
+  test data serves as a useful source of example inputs for many importers.
 
 
 ## Acknowledgements

--- a/docs/importer_schwab.md
+++ b/docs/importer_schwab.md
@@ -127,13 +127,13 @@ If you cannot obtain accurate position files, or if you need to provide initial 
             *   If the last three characters are digits (e.g., "Schwab123"), "123" is used as the identifier.
             *   Otherwise, the raw string is used (a warning may be logged).
         2.  `Date`: Position date in `YYYY-MM-DD` format (e.g., `2023-12-31`). This represents the balance at the **beginning** of this day. For year-end 2023 positions, use `2024-01-01`. 
-        3.  `Symbol`: Ticker symbol. Use "CASH" (case-insensitive) for cash positions.
+        3.  `Symbol`: Ticker symbol. Use "CASH <account_id>" (e.g., "CASH 789") for cash positions. Bare "CASH" is no longer supported to allow for multiple cash accounts.
         4.  `Quantity`: Number of shares/units or cash amount.
 *   **Example CSV**:
     ```csv
     Depot,Date,Symbol,Quantity
     AWARDS,2024-01-01,AAPL,100.5
-    Schwab789,2024-01-01,CASH,5000.75
+    Schwab789,2024-01-01,CASH 789,5000.75
     MyBroker123,2024-01-01,GOOG,20.0
     ```
 *   **Currency**: Currently defaults to "USD" for positions from this fallback CSV. All Cash is USD.

--- a/src/opensteuerauszug/importers/schwab/fallback_position_extractor.py
+++ b/src/opensteuerauszug/importers/schwab/fallback_position_extractor.py
@@ -124,6 +124,9 @@ class FallbackPositionExtractor:
                     pos = CashPosition(depot=processed_depot, currentCy=default_currency,
                                        cash_account_id=symbol_str[5:])
                     stock_name = "Manual Cash Position from CSV"
+                elif symbol_str == "CASH":
+                    print(f"FallbackPositionExtractor: Bare 'CASH' symbol in row {i+1} is no longer supported. Please use 'CASH <account_id>' (e.g., 'CASH 123'). Skipping row.")
+                    continue
                 else:
                     pos = SecurityPosition(depot=processed_depot, symbol=symbol_str, description=None)
                     stock_name = f"Manual Security Position for {symbol_str} from CSV"

--- a/src/opensteuerauszug/importers/schwab/fallback_position_extractor.py
+++ b/src/opensteuerauszug/importers/schwab/fallback_position_extractor.py
@@ -120,8 +120,9 @@ class FallbackPositionExtractor:
                 # This CSV format does not specify currency, so defaulting to USD.
                 default_currency = "USD"
 
-                if symbol_str == "CASH":
-                    pos = CashPosition(depot=processed_depot, currentCy=default_currency, cash_account_id=None)
+                if symbol_str.startswith("CASH "):
+                    pos = CashPosition(depot=processed_depot, currentCy=default_currency,
+                                       cash_account_id=symbol_str[5:])
                     stock_name = "Manual Cash Position from CSV"
                 else:
                     pos = SecurityPosition(depot=processed_depot, symbol=symbol_str, description=None)

--- a/src/opensteuerauszug/importers/schwab/transaction_extractor.py
+++ b/src/opensteuerauszug/importers/schwab/transaction_extractor.py
@@ -13,7 +13,8 @@ logger = logging.getLogger(__name__)
 KNOWN_ACTIONS = {
     "Buy", "Cash Dividend", "Cash In Lieu", "Credit Interest", "Deposit", "Dividend", "Journal",
     "Journaled Shares",
-    "ADR Mgmt Fee", "Adjustment", "Bond Interest", "Cash Merger", "Cash Merger Adj", "Div Adjustment", "Foreign Tax Paid", "Funds Received", "IRS Withhold Adj", "Long Term Cap Gain",
+    "ADR Mgmt Fee", "Adjustment", "Bond Interest", "Cash Merger", "Cash Merger Adj", "Div Adjustment",
+    "Full Redemption", "Full Redemption Adj", "Foreign Tax Paid", "Funds Received", "IRS Withhold Adj", "Long Term Cap Gain",
     "Misc Cash Entry", "MoneyLink Adj", "MoneyLink Deposit", "MoneyLink Transfer",
     "NRA Tax Adj", "NRA Withholding", "Non-Qualified Div", "Qualified Dividend", "Reinvest Dividend", "Qual Div Reinvest", "Reinvest Shares", "Sale", "Sell",
     "Service Fee", "Short Term Cap Gain", "Special Qual Div", "Spin-off", "Stock Plan Activity", "Stock Split",
@@ -465,18 +466,18 @@ class TransactionExtractor:
                 # Cash stock reflects the actual cash movement
                 cash_stock = create_cash_stock(schwab_amount, f"Cash flow for {action} {pos_object.symbol if isinstance(pos_object, SecurityPosition) else 'Cash'}")
 
-        elif action == "Cash Merger":
-            # Forced sale: cash received for the shares. Cash-only flow.
+        elif action in ("Cash Merger", "Full Redemption"):
+            # Forced sale/redemption: cash received for the shares. Cash-only flow.
             if schwab_amount and schwab_amount > 0:
-                cash_stock = create_cash_stock(schwab_amount, f"Cash in for Cash Merger {pos_object.symbol if isinstance(pos_object, SecurityPosition) else 'Cash'}")
+                cash_stock = create_cash_stock(schwab_amount, f"Cash in for {action} {pos_object.symbol if isinstance(pos_object, SecurityPosition) else 'Cash'}")
 
-        elif action == "Cash Merger Adj":
-            # Shares removed as part of a cash merger (quantity is negative)
+        elif action in ("Cash Merger Adj", "Full Redemption Adj"):
+            # Shares removed as part of a cash merger or full redemption (quantity is negative)
             if schwab_qty and isinstance(pos_object, SecurityPosition):
                 sec_stock = SecurityStock(
                     referenceDate=tx_date, mutation=True, quotationType="PIECE",
                     quantity=schwab_qty, balanceCurrency=currency,
-                    name="Cash Merger",
+                    name=action.replace(" Adj", ""),
                 )
 
         elif action == "Cash In Lieu":

--- a/src/opensteuerauszug/importers/schwab/transaction_extractor.py
+++ b/src/opensteuerauszug/importers/schwab/transaction_extractor.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 KNOWN_ACTIONS = {
     "Buy", "Cash Dividend", "Cash In Lieu", "Credit Interest", "Deposit", "Dividend", "Journal",
     "Journaled Shares",
-    "ADR Mgmt Fee", "Adjustment", "Bond Interest", "Div Adjustment", "Foreign Tax Paid", "Funds Received", "IRS Withhold Adj", "Long Term Cap Gain",
+    "ADR Mgmt Fee", "Adjustment", "Bond Interest", "Cash Merger", "Cash Merger Adj", "Div Adjustment", "Foreign Tax Paid", "Funds Received", "IRS Withhold Adj", "Long Term Cap Gain",
     "Misc Cash Entry", "MoneyLink Adj", "MoneyLink Deposit", "MoneyLink Transfer",
     "NRA Tax Adj", "NRA Withholding", "Non-Qualified Div", "Qualified Dividend", "Reinvest Dividend", "Qual Div Reinvest", "Reinvest Shares", "Sale", "Sell",
     "Service Fee", "Short Term Cap Gain", "Special Qual Div", "Spin-off", "Stock Plan Activity", "Stock Split",
@@ -464,6 +464,20 @@ class TransactionExtractor:
                 )
                 # Cash stock reflects the actual cash movement
                 cash_stock = create_cash_stock(schwab_amount, f"Cash flow for {action} {pos_object.symbol if isinstance(pos_object, SecurityPosition) else 'Cash'}")
+
+        elif action == "Cash Merger":
+            # Forced sale: cash received for the shares. Cash-only flow.
+            if schwab_amount and schwab_amount > 0:
+                cash_stock = create_cash_stock(schwab_amount, f"Cash in for Cash Merger {pos_object.symbol if isinstance(pos_object, SecurityPosition) else 'Cash'}")
+
+        elif action == "Cash Merger Adj":
+            # Shares removed as part of a cash merger (quantity is negative)
+            if schwab_qty and isinstance(pos_object, SecurityPosition):
+                sec_stock = SecurityStock(
+                    referenceDate=tx_date, mutation=True, quotationType="PIECE",
+                    quantity=schwab_qty, balanceCurrency=currency,
+                    name="Cash Merger",
+                )
 
         elif action == "Cash In Lieu":
              if schwab_amount and schwab_amount > 0:

--- a/src/opensteuerauszug/importers/schwab/transaction_extractor.py
+++ b/src/opensteuerauszug/importers/schwab/transaction_extractor.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 KNOWN_ACTIONS = {
     "Buy", "Cash Dividend", "Cash In Lieu", "Credit Interest", "Deposit", "Dividend", "Journal",
     "Journaled Shares",
-    "ADR Mgmt Fee", "Bond Interest", "Div Adjustment", "Foreign Tax Paid", "Funds Received", "IRS Withhold Adj", "Long Term Cap Gain",
+    "ADR Mgmt Fee", "Adjustment", "Bond Interest", "Div Adjustment", "Foreign Tax Paid", "Funds Received", "IRS Withhold Adj", "Long Term Cap Gain",
     "Misc Cash Entry", "MoneyLink Adj", "MoneyLink Deposit", "MoneyLink Transfer",
     "NRA Tax Adj", "NRA Withholding", "Non-Qualified Div", "Qualified Dividend", "Reinvest Dividend", "Qual Div Reinvest", "Reinvest Shares", "Sale", "Sell",
     "Service Fee", "Short Term Cap Gain", "Special Qual Div", "Stock Plan Activity", "Stock Split",
@@ -491,7 +491,7 @@ class TransactionExtractor:
         elif action in ("Wire Transfer", "MoneyLink Transfer", "MoneyLink Adj",
                         "Misc Cash Entry", "Service Fee", "Wire Funds", "Wire Sent",
                         "Funds Received", "Visa Purchase", "MoneyLink Deposit", "Wire Funds Received",
-                        "ADR Mgmt Fee"):
+                        "ADR Mgmt Fee", "Adjustment"):
             if schwab_amount:
                 cash_stock = create_cash_stock(schwab_amount, f"{action}{' ' + pos_object.symbol if isinstance(pos_object, SecurityPosition) else ''}")
 

--- a/src/opensteuerauszug/importers/schwab/transaction_extractor.py
+++ b/src/opensteuerauszug/importers/schwab/transaction_extractor.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 KNOWN_ACTIONS = {
     "Buy", "Cash Dividend", "Cash In Lieu", "Credit Interest", "Deposit", "Dividend", "Journal",
     "Journaled Shares",
-    "Bond Interest", "Div Adjustment", "Foreign Tax Paid", "Funds Received", "IRS Withhold Adj", "Long Term Cap Gain",
+    "ADR Mgmt Fee", "Bond Interest", "Div Adjustment", "Foreign Tax Paid", "Funds Received", "IRS Withhold Adj", "Long Term Cap Gain",
     "Misc Cash Entry", "MoneyLink Adj", "MoneyLink Deposit", "MoneyLink Transfer",
     "NRA Tax Adj", "NRA Withholding", "Non-Qualified Div", "Qualified Dividend", "Reinvest Dividend", "Qual Div Reinvest", "Reinvest Shares", "Sale", "Sell",
     "Service Fee", "Short Term Cap Gain", "Special Qual Div", "Stock Plan Activity", "Stock Split",
@@ -490,7 +490,8 @@ class TransactionExtractor:
 
         elif action in ("Wire Transfer", "MoneyLink Transfer", "MoneyLink Adj",
                         "Misc Cash Entry", "Service Fee", "Wire Funds", "Wire Sent",
-                        "Funds Received", "Visa Purchase", "MoneyLink Deposit", "Wire Funds Received"):
+                        "Funds Received", "Visa Purchase", "MoneyLink Deposit", "Wire Funds Received",
+                        "ADR Mgmt Fee"):
             if schwab_amount:
                 cash_stock = create_cash_stock(schwab_amount, f"{action}{' ' + pos_object.symbol if isinstance(pos_object, SecurityPosition) else ''}")
 

--- a/src/opensteuerauszug/importers/schwab/transaction_extractor.py
+++ b/src/opensteuerauszug/importers/schwab/transaction_extractor.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 KNOWN_ACTIONS = {
     "Buy", "Cash In Lieu", "Credit Interest", "Deposit", "Dividend", "Journal",
     "Journaled Shares",
-    "NRA Tax Adj", "Reinvest Dividend", "Qual Div Reinvest", "Reinvest Shares", "Sale", "Sell", "Stock Plan Activity", "Stock Split",
+    "NRA Tax Adj", "Qualified Dividend", "Reinvest Dividend", "Qual Div Reinvest", "Reinvest Shares", "Sale", "Sell", "Stock Plan Activity", "Stock Split",
     "Tax Reversal", "Tax Withholding", "Transfer", "Security Transfer", "Wire Transfer"
 }
 
@@ -348,7 +348,7 @@ class TransactionExtractor:
                 # Cash stock mutation
                 cash_stock = create_cash_stock(schwab_amount, f"Cash in for Credit Interest")
 
-        elif action == "Dividend" or action == "Reinvest Dividend" or action == "Qual Div Reinvest":
+        elif action in ("Dividend", "Reinvest Dividend", "Qual Div Reinvest", "Qualified Dividend"):
             if schwab_amount and schwab_amount > 0 and isinstance(pos_object, SecurityPosition):
                 if schwab_qty is not None and schwab_qty != Decimal(0):
                     print(f"Warning: Ignoring non-zero quantity ({schwab_qty}) for action '{action}' on symbol {pos_object.symbol}. Payment quantity will be uninitialized.")

--- a/src/opensteuerauszug/importers/schwab/transaction_extractor.py
+++ b/src/opensteuerauszug/importers/schwab/transaction_extractor.py
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)
 KNOWN_ACTIONS = {
     "Buy", "Cash Dividend", "Cash In Lieu", "Credit Interest", "Deposit", "Dividend", "Journal",
     "Journaled Shares",
+    "MoneyLink Transfer",
     "NRA Tax Adj", "Qualified Dividend", "Reinvest Dividend", "Qual Div Reinvest", "Reinvest Shares", "Sale", "Sell", "Stock Plan Activity", "Stock Split",
     "Tax Reversal", "Tax Withholding", "Transfer", "Security Transfer", "Wire Transfer"
 }
@@ -457,9 +458,9 @@ class TransactionExtractor:
                  # Just generate cash stock mutation
                  cash_stock = create_cash_stock(schwab_amount, "Cash Journal")
 
-        elif action == "Wire Transfer":
+        elif action in ("Wire Transfer", "MoneyLink Transfer"):
             if schwab_amount:
-                cash_stock = create_cash_stock(schwab_amount, f"Wire Transfer{' ' + pos_object.symbol if isinstance(pos_object, SecurityPosition) else ''}")
+                cash_stock = create_cash_stock(schwab_amount, f"{action}{' ' + pos_object.symbol if isinstance(pos_object, SecurityPosition) else ''}")
 
         elif action == "Transfer" or action == "Security Transfer":
             if schwab_qty and schwab_tx.get("Symbol") and isinstance(pos_object, SecurityPosition): # Share transfer

--- a/src/opensteuerauszug/importers/schwab/transaction_extractor.py
+++ b/src/opensteuerauszug/importers/schwab/transaction_extractor.py
@@ -13,9 +13,9 @@ logger = logging.getLogger(__name__)
 KNOWN_ACTIONS = {
     "Buy", "Cash Dividend", "Cash In Lieu", "Credit Interest", "Deposit", "Dividend", "Journal",
     "Journaled Shares",
-    "Bond Interest", "Div Adjustment", "Foreign Tax Paid", "IRS Withhold Adj", "MoneyLink Adj", "MoneyLink Transfer",
+    "Bond Interest", "Div Adjustment", "Foreign Tax Paid", "IRS Withhold Adj", "Long Term Cap Gain", "MoneyLink Adj", "MoneyLink Transfer",
     "NRA Tax Adj", "NRA Withholding", "Non-Qualified Div", "Qualified Dividend", "Reinvest Dividend", "Qual Div Reinvest", "Reinvest Shares", "Sale", "Sell",
-    "Special Qual Div", "Stock Plan Activity", "Stock Split",
+    "Short Term Cap Gain", "Special Qual Div", "Stock Plan Activity", "Stock Split",
     "Tax Reversal", "Tax Withholding", "Transfer", "Security Transfer", "Wire Transfer"
 }
 
@@ -368,6 +368,20 @@ class TransactionExtractor:
             else:
                 raise ValueError(f"Dividend action requires a positive amount and a valid SecurityPosition. Amount: {schwab_amount}, Position: {pos_object}")
                 
+        elif action in ("Short Term Cap Gain", "Long Term Cap Gain"):
+            # Capital gain distributions — treat like a dividend payment attached to the security
+            if schwab_amount and schwab_amount > 0 and isinstance(pos_object, SecurityPosition):
+                sec_payment = SecurityPayment(
+                    paymentDate=tx_date, quotationType="PIECE",
+                    quantity=UNINITIALIZED_QUANTITY, amountCurrency=currency,
+                    amount=schwab_amount, name="Capital Gain",
+                    grossRevenueB=schwab_amount,
+                    broker_label_original=action,
+                )
+                cash_stock = create_cash_stock(schwab_amount, f"Cash in for Capital Gain {pos_object.symbol}")
+            else:
+                raise ValueError(f"Capital gain action requires a positive amount and a valid SecurityPosition. Amount: {schwab_amount}, Position: {pos_object}")
+
         elif action == "Bond Interest":
             # Bond interest has a Symbol (CUSIP) — payment attaches to the security position
             if schwab_amount and schwab_amount > 0 and isinstance(pos_object, SecurityPosition):

--- a/src/opensteuerauszug/importers/schwab/transaction_extractor.py
+++ b/src/opensteuerauszug/importers/schwab/transaction_extractor.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 KNOWN_ACTIONS = {
     "Buy", "Cash Dividend", "Cash In Lieu", "Credit Interest", "Deposit", "Dividend", "Journal",
     "Journaled Shares",
-    "MoneyLink Transfer",
+    "Bond Interest", "MoneyLink Transfer",
     "NRA Tax Adj", "Qualified Dividend", "Reinvest Dividend", "Qual Div Reinvest", "Reinvest Shares", "Sale", "Sell", "Stock Plan Activity", "Stock Split",
     "Tax Reversal", "Tax Withholding", "Transfer", "Security Transfer", "Wire Transfer"
 }
@@ -366,6 +366,18 @@ class TransactionExtractor:
             else:
                 raise ValueError(f"Dividend action requires a positive amount and a valid SecurityPosition. Amount: {schwab_amount}, Position: {pos_object}")
                 
+        elif action == "Bond Interest":
+            # Bond interest has a Symbol (CUSIP) — payment attaches to the security position
+            if schwab_amount and schwab_amount > 0 and isinstance(pos_object, SecurityPosition):
+                sec_payment = SecurityPayment(
+                    paymentDate=tx_date, quotationType="PIECE",
+                    quantity=UNINITIALIZED_QUANTITY, amountCurrency=currency,
+                    amount=schwab_amount, name="Bond Interest",
+                    grossRevenueB=schwab_amount,
+                    broker_label_original=action,
+                )
+                cash_stock = create_cash_stock(schwab_amount, f"Cash in for Bond Interest {pos_object.symbol}")
+
         elif action == "Stock Split":
             if schwab_qty and schwab_qty != 0 and isinstance(pos_object, SecurityPosition):
                 # TODOD: Format date string in swiss format

--- a/src/opensteuerauszug/importers/schwab/transaction_extractor.py
+++ b/src/opensteuerauszug/importers/schwab/transaction_extractor.py
@@ -14,7 +14,7 @@ KNOWN_ACTIONS = {
     "Buy", "Cash In Lieu", "Credit Interest", "Deposit", "Dividend", "Journal",
     "Journaled Shares",
     "NRA Tax Adj", "Reinvest Dividend", "Qual Div Reinvest", "Reinvest Shares", "Sale", "Sell", "Stock Plan Activity", "Stock Split",
-    "Tax Withholding", "Transfer", "Security Transfer", "Wire Transfer"
+    "Tax Reversal", "Tax Withholding", "Transfer", "Security Transfer", "Wire Transfer"
 }
 
 class TransactionExtractor:
@@ -408,7 +408,7 @@ class TransactionExtractor:
                 # if cash_flow:
                 #     cash_stock = create_cash_stock(cash_flow, f"Implied cash out for Deposit {pos_object.symbol}")
         
-        elif action == "Tax Withholding" or action == "NRA Tax Adj":
+        elif action in ("Tax Withholding", "NRA Tax Adj", "Tax Reversal"):
             # Creates a Payment for the security AND a cash stock mutation
             if schwab_amount and schwab_amount != 0:
                 sec_payment = SecurityPayment(

--- a/src/opensteuerauszug/importers/schwab/transaction_extractor.py
+++ b/src/opensteuerauszug/importers/schwab/transaction_extractor.py
@@ -372,16 +372,11 @@ class TransactionExtractor:
                 raise ValueError(f"Dividend action requires a positive amount and a valid SecurityPosition. Amount: {schwab_amount}, Position: {pos_object}")
                 
         elif action in ("Short Term Cap Gain", "Long Term Cap Gain"):
-            # Capital gain distributions — treat like a dividend payment attached to the security
+            # Capital gain distributions are not recoverable or taxable in
+            # Switzerland (capital gains are tax-free for private investors), so
+            # we record only the cash flow without a taxable payment entry.
             if schwab_amount and schwab_amount > 0 and isinstance(pos_object, SecurityPosition):
-                sec_payment = SecurityPayment(
-                    paymentDate=tx_date, quotationType="PIECE",
-                    quantity=UNINITIALIZED_QUANTITY, amountCurrency=currency,
-                    amount=schwab_amount, name="Capital Gain",
-                    grossRevenueB=schwab_amount,
-                    broker_label_original=action,
-                )
-                cash_stock = create_cash_stock(schwab_amount, f"Cash in for Capital Gain {pos_object.symbol}")
+                cash_stock = create_cash_stock(schwab_amount, f"Cash in for {action} {pos_object.symbol}")
             else:
                 raise ValueError(f"Capital gain action requires a positive amount and a valid SecurityPosition. Amount: {schwab_amount}, Position: {pos_object}")
 
@@ -396,6 +391,8 @@ class TransactionExtractor:
                     broker_label_original=action,
                 )
                 cash_stock = create_cash_stock(schwab_amount, f"Cash in for Bond Interest {pos_object.symbol}")
+            else:
+                raise ValueError(f"Bond Interest action requires a positive amount and a valid SecurityPosition. Amount: {schwab_amount}, Position: {pos_object}")
 
         elif action == "Stock Split":
             if schwab_qty and schwab_qty != 0 and isinstance(pos_object, SecurityPosition):
@@ -412,7 +409,13 @@ class TransactionExtractor:
                 )
         
         elif action == "Spin-off":
-            # Corporate action: new shares appear in the account (no cash flow)
+            # Corporate action: new shares appear in the account. We don't model
+            # a cash component here, so reject any non-empty Amount loudly
+            # rather than silently dropping cash.
+            if schwab_amount is not None and schwab_amount != 0:
+                raise NotImplementedError(
+                    f"Spin-off with cash component is not handled. Amount: {schwab_amount}, transaction: {schwab_tx}"
+                )
             if schwab_qty and schwab_qty > 0 and isinstance(pos_object, SecurityPosition):
                 sec_stock = SecurityStock(
                     referenceDate=tx_date, mutation=True, quotationType="PIECE",
@@ -452,33 +455,58 @@ class TransactionExtractor:
                 #     cash_stock = create_cash_stock(cash_flow, f"Implied cash out for Deposit {pos_object.symbol}")
         
         elif action in ("Tax Withholding", "NRA Tax Adj", "Tax Reversal", "NRA Withholding", "Foreign Tax Paid", "IRS Withhold Adj"):
-            # Creates a Payment for the security AND a cash stock mutation
+            # Withholding-tax related entries only ever influence nonRecoverableTax,
+            # never grossRevenueB. A negative schwab_amount means tax was withheld
+            # (positive nonRecoverableTax); a positive schwab_amount means a
+            # reversal/refund (negative nonRecoverableTax) so it offsets a prior
+            # withholding for the same payment date.
+            # TODO: investigate whether IRS Withhold Adj and NRA Withholding need
+            # distinct handling from generic withholding (file an issue if so).
             if schwab_amount and schwab_amount != 0:
+                tax_amount = -schwab_amount
                 sec_payment = SecurityPayment(
                     paymentDate=tx_date, quotationType="PIECE",
                     quantity=UNINITIALIZED_QUANTITY, amountCurrency=currency, # Use currency string
                     amount=schwab_amount, name=f"{action}",
-                    nonRecoverableTax=abs(schwab_amount) if schwab_amount < 0 else None,
-                    grossRevenueB=schwab_amount if schwab_amount > 0 else None,
+                    nonRecoverableTax=tax_amount,
                     broker_label_original=action,
-                    nonRecoverableTaxAmountOriginal=abs(schwab_amount) if schwab_amount < 0 else None,
+                    nonRecoverableTaxAmountOriginal=tax_amount,
                 )
                 # Cash stock reflects the actual cash movement
                 cash_stock = create_cash_stock(schwab_amount, f"Cash flow for {action} {pos_object.symbol if isinstance(pos_object, SecurityPosition) else 'Cash'}")
+            else:
+                raise ValueError(f"Withholding tax action '{action}' requires a non-zero amount in transaction: {schwab_tx}")
 
         elif action in ("Cash Merger", "Full Redemption"):
-            # Forced sale/redemption: cash received for the shares. Cash-only flow.
-            if schwab_amount and schwab_amount > 0:
-                cash_stock = create_cash_stock(schwab_amount, f"Cash in for {action} {pos_object.symbol if isinstance(pos_object, SecurityPosition) else 'Cash'}")
+            # Forced sale/redemption: cash received for the shares. Cash-only
+            # flow — the share removal arrives in a separate "... Adj" entry.
+            if schwab_qty is not None and schwab_qty != 0:
+                raise ValueError(
+                    f"{action} should not carry a quantity component. Quantity: {schwab_qty}, transaction: {schwab_tx}"
+                )
+            if not schwab_amount or schwab_amount <= 0:
+                raise ValueError(
+                    f"{action} requires a positive amount. Amount: {schwab_amount}, transaction: {schwab_tx}"
+                )
+            cash_stock = create_cash_stock(schwab_amount, f"Cash in for {action} {pos_object.symbol if isinstance(pos_object, SecurityPosition) else 'Cash'}")
 
         elif action in ("Cash Merger Adj", "Full Redemption Adj"):
-            # Shares removed as part of a cash merger or full redemption (quantity is negative)
-            if schwab_qty and isinstance(pos_object, SecurityPosition):
-                sec_stock = SecurityStock(
-                    referenceDate=tx_date, mutation=True, quotationType="PIECE",
-                    quantity=schwab_qty, balanceCurrency=currency,
-                    name=action.replace(" Adj", ""),
+            # Shares removed as part of a cash merger or full redemption. The
+            # cash side arrives in the matching non-Adj entry, so this row must
+            # not also carry an Amount.
+            if schwab_amount is not None and schwab_amount != 0:
+                raise ValueError(
+                    f"{action} should not carry a cash amount (handled by matching '{action.replace(' Adj', '')}' entry). Amount: {schwab_amount}, transaction: {schwab_tx}"
                 )
+            if not schwab_qty or not isinstance(pos_object, SecurityPosition):
+                raise ValueError(
+                    f"{action} requires a non-zero quantity and a valid SecurityPosition. Quantity: {schwab_qty}, Position: {pos_object}, transaction: {schwab_tx}"
+                )
+            sec_stock = SecurityStock(
+                referenceDate=tx_date, mutation=True, quotationType="PIECE",
+                quantity=schwab_qty, balanceCurrency=currency,
+                name=action.replace(" Adj", ""),
+            )
 
         elif action == "Cash In Lieu":
              if schwab_amount and schwab_amount > 0:

--- a/src/opensteuerauszug/importers/schwab/transaction_extractor.py
+++ b/src/opensteuerauszug/importers/schwab/transaction_extractor.py
@@ -13,8 +13,8 @@ logger = logging.getLogger(__name__)
 KNOWN_ACTIONS = {
     "Buy", "Cash Dividend", "Cash In Lieu", "Credit Interest", "Deposit", "Dividend", "Journal",
     "Journaled Shares",
-    "Bond Interest", "Div Adjustment", "MoneyLink Adj", "MoneyLink Transfer",
-    "NRA Tax Adj", "Non-Qualified Div", "Qualified Dividend", "Reinvest Dividend", "Qual Div Reinvest", "Reinvest Shares", "Sale", "Sell",
+    "Bond Interest", "Div Adjustment", "Foreign Tax Paid", "IRS Withhold Adj", "MoneyLink Adj", "MoneyLink Transfer",
+    "NRA Tax Adj", "NRA Withholding", "Non-Qualified Div", "Qualified Dividend", "Reinvest Dividend", "Qual Div Reinvest", "Reinvest Shares", "Sale", "Sell",
     "Special Qual Div", "Stock Plan Activity", "Stock Split",
     "Tax Reversal", "Tax Withholding", "Transfer", "Security Transfer", "Wire Transfer"
 }
@@ -423,7 +423,7 @@ class TransactionExtractor:
                 # if cash_flow:
                 #     cash_stock = create_cash_stock(cash_flow, f"Implied cash out for Deposit {pos_object.symbol}")
         
-        elif action in ("Tax Withholding", "NRA Tax Adj", "Tax Reversal"):
+        elif action in ("Tax Withholding", "NRA Tax Adj", "Tax Reversal", "NRA Withholding", "Foreign Tax Paid", "IRS Withhold Adj"):
             # Creates a Payment for the security AND a cash stock mutation
             if schwab_amount and schwab_amount != 0:
                 sec_payment = SecurityPayment(

--- a/src/opensteuerauszug/importers/schwab/transaction_extractor.py
+++ b/src/opensteuerauszug/importers/schwab/transaction_extractor.py
@@ -528,11 +528,16 @@ class TransactionExtractor:
                 if schwab_amount and schwab_amount != 0:
                      calculated_value = schwab_amount
                      # If qty > 0 (in), cash is out? If qty < 0 (out), cash is in?
-                     cash_flow = -schwab_amount if schwab_qty > 0 else abs(schwab_amount) 
-                     
+                     cash_flow = -schwab_amount if schwab_qty > 0 else abs(schwab_amount)
+
+                # In equity awards files, a Journal (not "Journaled Shares") represents
+                # shares moving OUT to the brokerage account, so the sign is inverted
+                # relative to a brokerage Journal where positive qty = shares coming in.
+                final_qty = -schwab_qty if (action == "Journal" and pos_object.depot == "AWARDS") else schwab_qty
+
                 sec_stock = SecurityStock(
                     referenceDate=tx_date, mutation=True, quotationType="PIECE",
-                    quantity=schwab_qty, balanceCurrency=currency, # Use currency string
+                    quantity=final_qty, balanceCurrency=currency, # Use currency string
                     name=f"{action} (Shares)"
                 )
                 if cash_flow:

--- a/src/opensteuerauszug/importers/schwab/transaction_extractor.py
+++ b/src/opensteuerauszug/importers/schwab/transaction_extractor.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 KNOWN_ACTIONS = {
     "Buy", "Cash Dividend", "Cash In Lieu", "Credit Interest", "Deposit", "Dividend", "Journal",
     "Journaled Shares",
-    "Bond Interest", "MoneyLink Transfer",
+    "Bond Interest", "MoneyLink Adj", "MoneyLink Transfer",
     "NRA Tax Adj", "Qualified Dividend", "Reinvest Dividend", "Qual Div Reinvest", "Reinvest Shares", "Sale", "Sell", "Stock Plan Activity", "Stock Split",
     "Tax Reversal", "Tax Withholding", "Transfer", "Security Transfer", "Wire Transfer"
 }
@@ -470,7 +470,7 @@ class TransactionExtractor:
                  # Just generate cash stock mutation
                  cash_stock = create_cash_stock(schwab_amount, "Cash Journal")
 
-        elif action in ("Wire Transfer", "MoneyLink Transfer"):
+        elif action in ("Wire Transfer", "MoneyLink Transfer", "MoneyLink Adj"):
             if schwab_amount:
                 cash_stock = create_cash_stock(schwab_amount, f"{action}{' ' + pos_object.symbol if isinstance(pos_object, SecurityPosition) else ''}")
 

--- a/src/opensteuerauszug/importers/schwab/transaction_extractor.py
+++ b/src/opensteuerauszug/importers/schwab/transaction_extractor.py
@@ -13,8 +13,9 @@ logger = logging.getLogger(__name__)
 KNOWN_ACTIONS = {
     "Buy", "Cash Dividend", "Cash In Lieu", "Credit Interest", "Deposit", "Dividend", "Journal",
     "Journaled Shares",
-    "Bond Interest", "MoneyLink Adj", "MoneyLink Transfer",
-    "NRA Tax Adj", "Qualified Dividend", "Reinvest Dividend", "Qual Div Reinvest", "Reinvest Shares", "Sale", "Sell", "Stock Plan Activity", "Stock Split",
+    "Bond Interest", "Div Adjustment", "MoneyLink Adj", "MoneyLink Transfer",
+    "NRA Tax Adj", "Non-Qualified Div", "Qualified Dividend", "Reinvest Dividend", "Qual Div Reinvest", "Reinvest Shares", "Sale", "Sell",
+    "Special Qual Div", "Stock Plan Activity", "Stock Split",
     "Tax Reversal", "Tax Withholding", "Transfer", "Security Transfer", "Wire Transfer"
 }
 
@@ -349,7 +350,8 @@ class TransactionExtractor:
                 # Cash stock mutation
                 cash_stock = create_cash_stock(schwab_amount, f"Cash in for Credit Interest")
 
-        elif action in ("Dividend", "Reinvest Dividend", "Qual Div Reinvest", "Qualified Dividend", "Cash Dividend"):
+        elif action in ("Dividend", "Reinvest Dividend", "Qual Div Reinvest", "Qualified Dividend", "Cash Dividend",
+                        "Non-Qualified Div", "Special Qual Div", "Div Adjustment"):
             if schwab_amount and schwab_amount > 0 and isinstance(pos_object, SecurityPosition):
                 if schwab_qty is not None and schwab_qty != Decimal(0):
                     print(f"Warning: Ignoring non-zero quantity ({schwab_qty}) for action '{action}' on symbol {pos_object.symbol}. Payment quantity will be uninitialized.")

--- a/src/opensteuerauszug/importers/schwab/transaction_extractor.py
+++ b/src/opensteuerauszug/importers/schwab/transaction_extractor.py
@@ -13,9 +13,11 @@ logger = logging.getLogger(__name__)
 KNOWN_ACTIONS = {
     "Buy", "Cash Dividend", "Cash In Lieu", "Credit Interest", "Deposit", "Dividend", "Journal",
     "Journaled Shares",
-    "Bond Interest", "Div Adjustment", "Foreign Tax Paid", "IRS Withhold Adj", "Long Term Cap Gain", "MoneyLink Adj", "MoneyLink Transfer",
+    "Bond Interest", "Div Adjustment", "Foreign Tax Paid", "Funds Received", "IRS Withhold Adj", "Long Term Cap Gain",
+    "Misc Cash Entry", "MoneyLink Adj", "MoneyLink Deposit", "MoneyLink Transfer",
     "NRA Tax Adj", "NRA Withholding", "Non-Qualified Div", "Qualified Dividend", "Reinvest Dividend", "Qual Div Reinvest", "Reinvest Shares", "Sale", "Sell",
-    "Short Term Cap Gain", "Special Qual Div", "Stock Plan Activity", "Stock Split",
+    "Service Fee", "Short Term Cap Gain", "Special Qual Div", "Stock Plan Activity", "Stock Split",
+    "Visa Purchase", "Wire Funds", "Wire Funds Received", "Wire Sent",
     "Tax Reversal", "Tax Withholding", "Transfer", "Security Transfer", "Wire Transfer"
 }
 
@@ -486,7 +488,9 @@ class TransactionExtractor:
                  # Just generate cash stock mutation
                  cash_stock = create_cash_stock(schwab_amount, "Cash Journal")
 
-        elif action in ("Wire Transfer", "MoneyLink Transfer", "MoneyLink Adj"):
+        elif action in ("Wire Transfer", "MoneyLink Transfer", "MoneyLink Adj",
+                        "Misc Cash Entry", "Service Fee", "Wire Funds", "Wire Sent",
+                        "Funds Received", "Visa Purchase", "MoneyLink Deposit", "Wire Funds Received"):
             if schwab_amount:
                 cash_stock = create_cash_stock(schwab_amount, f"{action}{' ' + pos_object.symbol if isinstance(pos_object, SecurityPosition) else ''}")
 

--- a/src/opensteuerauszug/importers/schwab/transaction_extractor.py
+++ b/src/opensteuerauszug/importers/schwab/transaction_extractor.py
@@ -16,7 +16,7 @@ KNOWN_ACTIONS = {
     "ADR Mgmt Fee", "Adjustment", "Bond Interest", "Div Adjustment", "Foreign Tax Paid", "Funds Received", "IRS Withhold Adj", "Long Term Cap Gain",
     "Misc Cash Entry", "MoneyLink Adj", "MoneyLink Deposit", "MoneyLink Transfer",
     "NRA Tax Adj", "NRA Withholding", "Non-Qualified Div", "Qualified Dividend", "Reinvest Dividend", "Qual Div Reinvest", "Reinvest Shares", "Sale", "Sell",
-    "Service Fee", "Short Term Cap Gain", "Special Qual Div", "Stock Plan Activity", "Stock Split",
+    "Service Fee", "Short Term Cap Gain", "Special Qual Div", "Spin-off", "Stock Plan Activity", "Stock Split",
     "Visa Purchase", "Wire Funds", "Wire Funds Received", "Wire Sent",
     "Tax Reversal", "Tax Withholding", "Transfer", "Security Transfer", "Wire Transfer"
 }
@@ -410,6 +410,17 @@ class TransactionExtractor:
                     name=name
                 )
         
+        elif action == "Spin-off":
+            # Corporate action: new shares appear in the account (no cash flow)
+            if schwab_qty and schwab_qty > 0 and isinstance(pos_object, SecurityPosition):
+                sec_stock = SecurityStock(
+                    referenceDate=tx_date, mutation=True, quotationType="PIECE",
+                    quantity=schwab_qty, balanceCurrency=currency,
+                    name="Spin-off",
+                )
+            else:
+                raise ValueError(f"Spin-off action requires a positive quantity and a valid SecurityPosition. Quantity: {schwab_qty}, Position: {pos_object}")
+
         elif action == "Deposit": # Shares deposited into account
             if schwab_qty and schwab_qty > 0 and isinstance(pos_object, SecurityPosition):
                 award_details_str = ""

--- a/src/opensteuerauszug/importers/schwab/transaction_extractor.py
+++ b/src/opensteuerauszug/importers/schwab/transaction_extractor.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 # Known actions from formats.md
 KNOWN_ACTIONS = {
-    "Buy", "Cash In Lieu", "Credit Interest", "Deposit", "Dividend", "Journal",
+    "Buy", "Cash Dividend", "Cash In Lieu", "Credit Interest", "Deposit", "Dividend", "Journal",
     "Journaled Shares",
     "NRA Tax Adj", "Qualified Dividend", "Reinvest Dividend", "Qual Div Reinvest", "Reinvest Shares", "Sale", "Sell", "Stock Plan Activity", "Stock Split",
     "Tax Reversal", "Tax Withholding", "Transfer", "Security Transfer", "Wire Transfer"
@@ -348,7 +348,7 @@ class TransactionExtractor:
                 # Cash stock mutation
                 cash_stock = create_cash_stock(schwab_amount, f"Cash in for Credit Interest")
 
-        elif action in ("Dividend", "Reinvest Dividend", "Qual Div Reinvest", "Qualified Dividend"):
+        elif action in ("Dividend", "Reinvest Dividend", "Qual Div Reinvest", "Qualified Dividend", "Cash Dividend"):
             if schwab_amount and schwab_amount > 0 and isinstance(pos_object, SecurityPosition):
                 if schwab_qty is not None and schwab_qty != Decimal(0):
                     print(f"Warning: Ignoring non-zero quantity ({schwab_qty}) for action '{action}' on symbol {pos_object.symbol}. Payment quantity will be uninitialized.")

--- a/tests/importers/schwab/test_fallback_position_extractor.py
+++ b/tests/importers/schwab/test_fallback_position_extractor.py
@@ -199,7 +199,7 @@ def test_extract_positions_valid_csv_awards_security(managed_temp_csv_path):
     assert stock.quotationType == "PIECE"
     assert stock.name == "Manual Security Position for AAPL from CSV"
 
-@pytest.mark.parametrize("managed_temp_csv_path", ["Depot,Date,Symbol,Quantity\nSCHWABACC789,2023-03-10,CASH,5000.75\n"], indirect=True)
+@pytest.mark.parametrize("managed_temp_csv_path", ["Depot,Date,Symbol,Quantity\nSCHWABACC789,2023-03-10,CASH 789,5000.75\n"], indirect=True)
 def test_extract_positions_valid_csv_numeric_depot_cash(managed_temp_csv_path):
     extractor = FallbackPositionExtractor(managed_temp_csv_path)
     results = extractor.extract_positions()
@@ -211,7 +211,7 @@ def test_extract_positions_valid_csv_numeric_depot_cash(managed_temp_csv_path):
     assert isinstance(pos, CashPosition)
     assert pos.depot == "789" # Last 3 digits
     assert pos.currentCy == "USD"
-    assert pos.cash_account_id is None
+    assert pos.cash_account_id == "789"
 
     assert isinstance(stock, SecurityStock)
     assert stock.referenceDate == date(2023, 3, 10)
@@ -360,7 +360,7 @@ def test_extract_positions_empty_symbol_skips_row(managed_temp_csv_path):
 @pytest.mark.parametrize("managed_temp_csv_path", [(
             "Depot,Date,Symbol,Quantity\n"
             "AWARDS,2023-01-01,AAPL,10\n"
-            "ACC123,2023-01-15,CASH,1000.00\n"
+            "ACC123,2023-01-15,CASH 123,1000.00\n"
             "AWARDS,2023-02-01,MSFT,25.5\n"
         )], indirect=True)
 def test_extract_positions_multiple_valid_entries(managed_temp_csv_path):
@@ -382,6 +382,7 @@ def test_extract_positions_multiple_valid_entries(managed_temp_csv_path):
     pos2, stock2 = results[1]
     assert isinstance(pos2, CashPosition)
     assert pos2.depot == "123"
+    assert pos2.cash_account_id == "123"
     assert stock2.quantity == Decimal("1000.00")
     assert stock2.referenceDate == date(2023,1,15)
 
@@ -392,6 +393,17 @@ def test_extract_positions_multiple_valid_entries(managed_temp_csv_path):
     assert pos3.symbol == "MSFT"
     assert stock3.quantity == Decimal("25.5")
     assert stock3.referenceDate == date(2023,2,1)
+
+@pytest.mark.parametrize("managed_temp_csv_path", ["Depot,Date,Symbol,Quantity\nACC123,2023-01-15,CASH,1000.00\n"], indirect=True)
+def test_extract_positions_bare_cash_unsupported(managed_temp_csv_path):
+    extractor = FallbackPositionExtractor(managed_temp_csv_path)
+    log_capture = StringIO()
+    with contextlib.redirect_stdout(log_capture):
+        results = extractor.extract_positions()
+    
+    assert results is None
+    assert "Bare 'CASH' symbol in row 1 is no longer supported" in log_capture.getvalue()
+    assert "Please use 'CASH <account_id>'" in log_capture.getvalue()
 
 @pytest.mark.parametrize("managed_temp_csv_path", [
     # UTF-8 BOM is \xef\xbb\xbf

--- a/tests/importers/schwab/test_transaction_extractor.py
+++ b/tests/importers/schwab/test_transaction_extractor.py
@@ -1424,3 +1424,31 @@ class TestSchwabTransactionExtractor:
         assert stock.mutation is True
         assert stock.quantity == Decimal("-2.50")
         assert "ADR Mgmt Fee" in stock.name
+
+    def test_action_adjustment(self):
+        """Adjustment with positive and negative amounts creates cash mutations."""
+        extractor = create_extractor()
+        data = {
+            "FromDate": "01/01/2024", "ToDate": "12/31/2024",
+            "BrokerageTransactions": [
+                {
+                    "Date": "03/15/2024", "Action": "Adjustment",
+                    "Description": "POSITIVE ADJUSTMENT", "Amount": "$25.00"
+                },
+                {
+                    "Date": "06/15/2024", "Action": "Adjustment",
+                    "Description": "NEGATIVE ADJUSTMENT", "Amount": "-$10.00"
+                },
+            ]
+        }
+        result = run_extraction_test(extractor, data, 1)  # Both merge into 1 CashPosition
+        assert result is not None
+        cash_data = find_position(result, CashPosition)
+        assert cash_data is not None
+        pos, stocks, payments = cash_data
+        assert isinstance(pos, CashPosition)
+        assert payments is None
+        assert stocks is not None
+        assert len(stocks) == 2
+        quantities = sorted([s.quantity for s in stocks])
+        assert quantities == [Decimal("-10.00"), Decimal("25.00")]

--- a/tests/importers/schwab/test_transaction_extractor.py
+++ b/tests/importers/schwab/test_transaction_extractor.py
@@ -1145,3 +1145,51 @@ class TestSchwabTransactionExtractor:
         cash_pos, cash_stocks, _ = cash_data
         assert len(cash_stocks) == 1
         assert cash_stocks[0].quantity == Decimal("35.00")
+
+    def test_action_moneylink_transfer_positive(self):
+        """MoneyLink Transfer with positive amount creates a cash mutation."""
+        extractor = create_extractor()
+        data = {
+            "FromDate": "01/01/2016", "ToDate": "12/31/2016",
+            "BrokerageTransactions": [{
+                "Date": "03/01/2016", "Action": "MoneyLink Transfer",
+                "Description": "Tfr BANK", "Amount": "$10000.00"
+            }]
+        }
+        result = run_extraction_test(extractor, data, 1)
+        assert result is not None
+        cash_data = find_position(result, CashPosition)
+        assert cash_data is not None
+        pos, stocks, payments = cash_data
+        assert isinstance(pos, CashPosition)
+        assert payments is None
+        assert stocks is not None
+        assert len(stocks) == 1
+        stock = stocks[0]
+        assert stock.referenceDate == date(2016, 3, 1)
+        assert stock.mutation is True
+        assert stock.quantity == Decimal("10000.00")
+        assert "MoneyLink Transfer" in stock.name
+
+    def test_action_moneylink_transfer_negative(self):
+        """MoneyLink Transfer with negative amount creates a cash outflow mutation."""
+        extractor = create_extractor()
+        data = {
+            "FromDate": "01/01/2016", "ToDate": "12/31/2016",
+            "BrokerageTransactions": [{
+                "Date": "03/15/2016", "Action": "MoneyLink Transfer",
+                "Description": "Tfr BANK OUT", "Amount": "-$5000.00"
+            }]
+        }
+        result = run_extraction_test(extractor, data, 1)
+        assert result is not None
+        cash_data = find_position(result, CashPosition)
+        assert cash_data is not None
+        pos, stocks, payments = cash_data
+        assert isinstance(pos, CashPosition)
+        assert payments is None
+        assert stocks is not None
+        assert len(stocks) == 1
+        stock = stocks[0]
+        assert stock.quantity == Decimal("-5000.00")
+        assert "MoneyLink Transfer" in stock.name

--- a/tests/importers/schwab/test_transaction_extractor.py
+++ b/tests/importers/schwab/test_transaction_extractor.py
@@ -1047,3 +1047,39 @@ class TestSchwabTransactionExtractor:
         assert stock.quantity == Decimal("15.0")
         assert stock.unitPrice is None
         assert stock.name == "Stock Plan Activity"
+
+    def test_action_tax_reversal(self):
+        """Tax Reversal with positive amount generates SecurityPayment + cash mutation (like NRA Tax Adj positive)."""
+        extractor = create_extractor()
+        data = {
+            "FromDate": "01/01/2024", "ToDate": "12/31/2024",
+            "BrokerageTransactions": [{
+                "Date": "07/12/2024", "Action": "Tax Reversal", "Symbol": "GOOG",
+                "Quantity": None, "Description": "Credit",
+                "FeesAndCommissions": None, "Amount": "$11.20",
+                "TransactionDetails": []
+            }]
+        }
+        result = run_extraction_test(extractor, data, 2)  # GOOG + Cash
+        assert result is not None
+        goog_data = find_position(result, SecurityPosition, "GOOG")
+        cash_data = find_position(result, CashPosition)
+        assert goog_data is not None
+        assert cash_data is not None
+
+        pos, stocks, payments = goog_data
+        assert isinstance(pos, SecurityPosition)
+        assert pos.symbol == "GOOG"
+        assert not stocks
+        assert payments is not None
+        assert len(payments) == 1
+        payment = payments[0]
+        assert payment.amount == Decimal("11.20")
+        assert payment.grossRevenueB == Decimal("11.20")
+        assert payment.nonRecoverableTax is None
+        assert payment.name == "Tax Reversal"
+
+        cash_pos, cash_stocks, _ = cash_data
+        assert isinstance(cash_pos, CashPosition)
+        assert len(cash_stocks) == 1
+        assert cash_stocks[0].quantity == Decimal("11.20")

--- a/tests/importers/schwab/test_transaction_extractor.py
+++ b/tests/importers/schwab/test_transaction_extractor.py
@@ -1530,6 +1530,36 @@ class TestSchwabTransactionExtractor:
         assert len(cash_stocks) == 1
         assert cash_stocks[0].quantity == Decimal("1000")
 
+    def test_action_journal_awards_share_transfer_out(self):
+        """In equity awards files, a Journal with positive quantity is a share transfer OUT (inverse of brokerage Journals)."""
+        extractor = create_extractor()
+        data = {
+            "FromDate": "01/01/2025", "ToDate": "12/31/2025",
+            "Transactions": [{
+                "Date": "03/15/2025", "Action": "Journal", "Symbol": "ACME",
+                "Quantity": "42.500", "Description": "Share Transfer",
+                "FeesAndCommissions": None, "DisbursementElection": None,
+                "Amount": None, "TransactionDetails": []
+            }]
+        }
+        result = run_extraction_test(extractor, data, 1)
+        assert result is not None
+        acme_data = find_position(result, SecurityPosition, "ACME")
+        assert acme_data is not None
+
+        pos, stocks, payments = acme_data
+        assert isinstance(pos, SecurityPosition)
+        assert pos.symbol == "ACME"
+        assert pos.depot == "AWARDS"
+        assert payments is None
+        assert len(stocks) == 1
+        stock = stocks[0]
+        assert stock.referenceDate == date(2025, 3, 15)
+        assert stock.mutation is True
+        # Awards Journal with positive Schwab qty = shares leaving the awards account → negative
+        assert stock.quantity == Decimal("-42.500")
+        assert stock.name == "Journal (Shares)"
+
     def test_action_full_redemption(self):
         """Full Redemption creates cash inflow; Full Redemption Adj removes shares from the SecurityPosition."""
         extractor = create_extractor()

--- a/tests/importers/schwab/test_transaction_extractor.py
+++ b/tests/importers/schwab/test_transaction_extractor.py
@@ -1363,3 +1363,39 @@ class TestSchwabTransactionExtractor:
             assert payment.name == "Capital Gain", f"Payment name for {action_str} should be 'Capital Gain'"
             assert payment.broker_label_original == action_str
             assert payment.grossRevenueB == Decimal(amount)
+
+    def test_action_cash_transfer_variants(self):
+        """Misc Cash Entry, Service Fee, Wire Funds, Wire Sent, Funds Received, Visa Purchase, MoneyLink Deposit, Wire Funds Received are all cash-only."""
+        extractor = create_extractor()
+        data = {
+            "FromDate": "01/01/2024", "ToDate": "12/31/2024",
+            "BrokerageTransactions": [
+                {
+                    "Date": "03/15/2024", "Action": "Service Fee",
+                    "Description": "SERVICE FEE", "Amount": "-$5.00"
+                },
+                {
+                    "Date": "06/15/2024", "Action": "Funds Received",
+                    "Description": "ACH DEPOSIT", "Amount": "$1000.00"
+                },
+                {
+                    "Date": "09/15/2024", "Action": "Wire Funds",
+                    "Description": "WIRE OUT", "Amount": "-$500.00"
+                },
+            ]
+        }
+        result = run_extraction_test(extractor, data, 1)  # All merge into 1 CashPosition
+        assert result is not None
+        cash_data = find_position(result, CashPosition)
+        assert cash_data is not None
+        pos, stocks, payments = cash_data
+        assert isinstance(pos, CashPosition)
+        assert payments is None
+        assert stocks is not None
+        assert len(stocks) == 3
+        service_fee_stock = next(s for s in stocks if "Service Fee" in s.name)
+        assert service_fee_stock.quantity == Decimal("-5.00")
+        funds_received_stock = next(s for s in stocks if "Funds Received" in s.name)
+        assert funds_received_stock.quantity == Decimal("1000.00")
+        wire_funds_stock = next(s for s in stocks if "Wire Funds" in s.name)
+        assert wire_funds_stock.quantity == Decimal("-500.00")

--- a/tests/importers/schwab/test_transaction_extractor.py
+++ b/tests/importers/schwab/test_transaction_extractor.py
@@ -1481,3 +1481,43 @@ class TestSchwabTransactionExtractor:
         # No cash position expected (no cash flow)
         cash_data = find_position(result, CashPosition)
         assert cash_data is None
+
+    def test_action_cash_merger(self):
+        """Cash Merger creates cash inflow; Cash Merger Adj creates negative SecurityStock for shares removed."""
+        extractor = create_extractor()
+        data = {
+            "FromDate": "01/01/2021", "ToDate": "12/31/2021",
+            "BrokerageTransactions": [
+                {
+                    "Date": "03/02/2021", "Action": "Cash Merger", "Symbol": "FOO",
+                    "Description": "FOO INC", "Amount": "$1000"
+                },
+                {
+                    "Date": "03/02/2021", "Action": "Cash Merger Adj", "Symbol": "FOO",
+                    "Description": "FOO INC", "Quantity": "-100"
+                },
+            ]
+        }
+        result = run_extraction_test(extractor, data, 2)  # FOO SecurityPosition + CashPosition
+        assert result is not None
+        foo_data = find_position(result, SecurityPosition, "FOO")
+        cash_data = find_position(result, CashPosition)
+        assert foo_data is not None
+        assert cash_data is not None
+
+        pos, stocks, payments = foo_data
+        assert isinstance(pos, SecurityPosition)
+        assert pos.symbol == "FOO"
+        assert payments is None
+        assert stocks is not None
+        assert len(stocks) == 1
+        stock = stocks[0]
+        assert stock.quantity == Decimal("-100")
+        assert stock.name == "Cash Merger"
+
+        cash_pos, cash_stocks, cash_payments = cash_data
+        assert isinstance(cash_pos, CashPosition)
+        assert cash_payments is None
+        assert cash_stocks is not None
+        assert len(cash_stocks) == 1
+        assert cash_stocks[0].quantity == Decimal("1000")

--- a/tests/importers/schwab/test_transaction_extractor.py
+++ b/tests/importers/schwab/test_transaction_extractor.py
@@ -1257,3 +1257,40 @@ class TestSchwabTransactionExtractor:
         assert stock.mutation is True
         assert stock.quantity == Decimal("10.00")
         assert "MoneyLink Adj" in stock.name
+
+    def test_action_dividend_variants(self):
+        """Non-Qualified Div, Special Qual Div, and Div Adjustment are all handled like Dividend."""
+        extractor = create_extractor()
+        data = {
+            "FromDate": "01/01/2024", "ToDate": "12/31/2024",
+            "BrokerageTransactions": [
+                {
+                    "Date": "03/15/2024", "Action": "Non-Qualified Div", "Symbol": "MSFT",
+                    "Description": "MICROSOFT CORP", "Amount": "$25.00"
+                },
+                {
+                    "Date": "06/15/2024", "Action": "Special Qual Div", "Symbol": "GOOG",
+                    "Description": "ALPHABET INC", "Amount": "$50.00"
+                },
+                {
+                    "Date": "09/15/2024", "Action": "Div Adjustment", "Symbol": "AAPL",
+                    "Description": "APPLE INC", "Amount": "$10.00"
+                },
+            ]
+        }
+        result = run_extraction_test(extractor, data, 4)  # 3 SecurityPositions + 1 CashPosition
+        assert result is not None
+
+        for symbol, action_str, amount in [("MSFT", "Non-Qualified Div", "25.00"),
+                                           ("GOOG", "Special Qual Div", "50.00"),
+                                           ("AAPL", "Div Adjustment", "10.00")]:
+            sec_data = find_position(result, SecurityPosition, symbol)
+            assert sec_data is not None, f"SecurityPosition for {symbol} not found"
+            pos, stocks, payments = sec_data
+            assert isinstance(pos, SecurityPosition)
+            assert not stocks
+            assert payments is not None and len(payments) == 1
+            payment = payments[0]
+            assert payment.name == "Dividend", f"Payment name for {action_str} should be 'Dividend'"
+            assert payment.broker_label_original == action_str
+            assert payment.grossRevenueB == Decimal(amount)

--- a/tests/importers/schwab/test_transaction_extractor.py
+++ b/tests/importers/schwab/test_transaction_extractor.py
@@ -1232,3 +1232,28 @@ class TestSchwabTransactionExtractor:
         assert len(cash_stocks) == 1
         assert cash_stocks[0].quantity == Decimal("500.00")
         assert cash_stocks[0].name == "Cash in for Bond Interest 912828YW8"
+
+    def test_action_moneylink_adj(self):
+        """MoneyLink Adj creates a cash mutation, same as MoneyLink Transfer."""
+        extractor = create_extractor()
+        data = {
+            "FromDate": "01/01/2016", "ToDate": "12/31/2016",
+            "BrokerageTransactions": [{
+                "Date": "07/01/2016", "Action": "MoneyLink Adj",
+                "Description": "Tfr BANK", "Amount": "$10.00"
+            }]
+        }
+        result = run_extraction_test(extractor, data, 1)
+        assert result is not None
+        cash_data = find_position(result, CashPosition)
+        assert cash_data is not None
+        pos, stocks, payments = cash_data
+        assert isinstance(pos, CashPosition)
+        assert payments is None
+        assert stocks is not None
+        assert len(stocks) == 1
+        stock = stocks[0]
+        assert stock.referenceDate == date(2016, 7, 1)
+        assert stock.mutation is True
+        assert stock.quantity == Decimal("10.00")
+        assert "MoneyLink Adj" in stock.name

--- a/tests/importers/schwab/test_transaction_extractor.py
+++ b/tests/importers/schwab/test_transaction_extractor.py
@@ -1521,3 +1521,43 @@ class TestSchwabTransactionExtractor:
         assert cash_stocks is not None
         assert len(cash_stocks) == 1
         assert cash_stocks[0].quantity == Decimal("1000")
+
+    def test_action_full_redemption(self):
+        """Full Redemption creates cash inflow; Full Redemption Adj removes shares from the SecurityPosition."""
+        extractor = create_extractor()
+        data = {
+            "FromDate": "01/01/2023", "ToDate": "12/31/2023",
+            "BrokerageTransactions": [
+                {
+                    "Date": "06/01/2023", "Action": "Full Redemption", "Symbol": "BOND1",
+                    "Description": "BOND INC", "Amount": "$5000"
+                },
+                {
+                    "Date": "06/01/2023", "Action": "Full Redemption Adj", "Symbol": "BOND1",
+                    "Description": "BOND INC", "Quantity": "-50"
+                },
+            ]
+        }
+        result = run_extraction_test(extractor, data, 2)  # BOND1 SecurityPosition + CashPosition
+        assert result is not None
+        bond_data = find_position(result, SecurityPosition, "BOND1")
+        cash_data = find_position(result, CashPosition)
+        assert bond_data is not None
+        assert cash_data is not None
+
+        pos, stocks, payments = bond_data
+        assert isinstance(pos, SecurityPosition)
+        assert pos.symbol == "BOND1"
+        assert payments is None
+        assert stocks is not None
+        assert len(stocks) == 1
+        stock = stocks[0]
+        assert stock.quantity == Decimal("-50")
+        assert stock.name == "Full Redemption"
+
+        cash_pos, cash_stocks, cash_payments = cash_data
+        assert isinstance(cash_pos, CashPosition)
+        assert cash_payments is None
+        assert cash_stocks is not None
+        assert len(cash_stocks) == 1
+        assert cash_stocks[0].quantity == Decimal("5000")

--- a/tests/importers/schwab/test_transaction_extractor.py
+++ b/tests/importers/schwab/test_transaction_extractor.py
@@ -1115,3 +1115,33 @@ class TestSchwabTransactionExtractor:
         cash_pos, cash_stocks, _ = cash_data
         assert len(cash_stocks) == 1
         assert cash_stocks[0].quantity == Decimal("50.00")
+
+    def test_action_cash_dividend(self):
+        """Cash Dividend is handled like a regular Dividend."""
+        extractor = create_extractor()
+        data = {
+            "FromDate": "01/01/2024", "ToDate": "12/31/2024",
+            "BrokerageTransactions": [{
+                "Date": "06/15/2024", "Action": "Cash Dividend", "Symbol": "MSFT",
+                "Description": "Cash Dividend", "Amount": "$35.00"
+            }]
+        }
+        result = run_extraction_test(extractor, data, 2)  # MSFT + Cash
+        assert result is not None
+        msft_data = find_position(result, SecurityPosition, "MSFT")
+        cash_data = find_position(result, CashPosition)
+        assert msft_data is not None
+        assert cash_data is not None
+
+        pos, stocks, payments = msft_data
+        assert not stocks
+        assert payments is not None
+        assert len(payments) == 1
+        payment = payments[0]
+        assert payment.grossRevenueB == Decimal("35.00")
+        assert payment.name == "Dividend"
+        assert payment.broker_label_original == "Cash Dividend"
+
+        cash_pos, cash_stocks, _ = cash_data
+        assert len(cash_stocks) == 1
+        assert cash_stocks[0].quantity == Decimal("35.00")

--- a/tests/importers/schwab/test_transaction_extractor.py
+++ b/tests/importers/schwab/test_transaction_extractor.py
@@ -1083,3 +1083,35 @@ class TestSchwabTransactionExtractor:
         assert isinstance(cash_pos, CashPosition)
         assert len(cash_stocks) == 1
         assert cash_stocks[0].quantity == Decimal("11.20")
+
+    def test_action_qualified_dividend(self):
+        """Qualified Dividend is handled like a regular Dividend."""
+        extractor = create_extractor()
+        data = {
+            "FromDate": "01/01/2024", "ToDate": "12/31/2024",
+            "BrokerageTransactions": [{
+                "Date": "06/15/2024", "Action": "Qualified Dividend", "Symbol": "AAPL",
+                "Description": "Qualified Dividend", "Amount": "$50.00"
+            }]
+        }
+        result = run_extraction_test(extractor, data, 2)  # AAPL + Cash
+        assert result is not None
+        aapl_data = find_position(result, SecurityPosition, "AAPL")
+        cash_data = find_position(result, CashPosition)
+        assert aapl_data is not None
+        assert cash_data is not None
+
+        pos, stocks, payments = aapl_data
+        assert isinstance(pos, SecurityPosition)
+        assert pos.symbol == "AAPL"
+        assert not stocks
+        assert payments is not None
+        assert len(payments) == 1
+        payment = payments[0]
+        assert payment.grossRevenueB == Decimal("50.00")
+        assert payment.name == "Dividend"
+        assert payment.broker_label_original == "Qualified Dividend"
+
+        cash_pos, cash_stocks, _ = cash_data
+        assert len(cash_stocks) == 1
+        assert cash_stocks[0].quantity == Decimal("50.00")

--- a/tests/importers/schwab/test_transaction_extractor.py
+++ b/tests/importers/schwab/test_transaction_extractor.py
@@ -1399,3 +1399,28 @@ class TestSchwabTransactionExtractor:
         assert funds_received_stock.quantity == Decimal("1000.00")
         wire_funds_stock = next(s for s in stocks if "Wire Funds" in s.name)
         assert wire_funds_stock.quantity == Decimal("-500.00")
+
+    def test_action_adr_mgmt_fee(self):
+        """ADR Mgmt Fee with negative amount creates a cash outflow mutation."""
+        extractor = create_extractor()
+        data = {
+            "FromDate": "01/01/2024", "ToDate": "12/31/2024",
+            "BrokerageTransactions": [{
+                "Date": "06/15/2024", "Action": "ADR Mgmt Fee",
+                "Description": "ADR FEE", "Amount": "-$2.50"
+            }]
+        }
+        result = run_extraction_test(extractor, data, 1)
+        assert result is not None
+        cash_data = find_position(result, CashPosition)
+        assert cash_data is not None
+        pos, stocks, payments = cash_data
+        assert isinstance(pos, CashPosition)
+        assert payments is None
+        assert stocks is not None
+        assert len(stocks) == 1
+        stock = stocks[0]
+        assert stock.referenceDate == date(2024, 6, 15)
+        assert stock.mutation is True
+        assert stock.quantity == Decimal("-2.50")
+        assert "ADR Mgmt Fee" in stock.name

--- a/tests/importers/schwab/test_transaction_extractor.py
+++ b/tests/importers/schwab/test_transaction_extractor.py
@@ -1452,3 +1452,32 @@ class TestSchwabTransactionExtractor:
         assert len(stocks) == 2
         quantities = sorted([s.quantity for s in stocks])
         assert quantities == [Decimal("-10.00"), Decimal("25.00")]
+
+    def test_action_spin_off(self):
+        """Spin-off creates a SecurityStock with positive quantity and no cash flow."""
+        extractor = create_extractor()
+        data = {
+            "FromDate": "01/01/2024", "ToDate": "12/31/2024",
+            "BrokerageTransactions": [{
+                "Date": "05/01/2024", "Action": "Spin-off", "Symbol": "NEWCO",
+                "Description": "NEWCO INC SPINOFF", "Quantity": "10"
+            }]
+        }
+        result = run_extraction_test(extractor, data, 1)  # Just the SecurityPosition
+        assert result is not None
+        newco_data = find_position(result, SecurityPosition, "NEWCO")
+        assert newco_data is not None
+        pos, stocks, payments = newco_data
+        assert isinstance(pos, SecurityPosition)
+        assert pos.symbol == "NEWCO"
+        assert payments is None
+        assert stocks is not None
+        assert len(stocks) == 1
+        stock = stocks[0]
+        assert stock.referenceDate == date(2024, 5, 1)
+        assert stock.mutation is True
+        assert stock.quantity == Decimal("10")
+        assert stock.name == "Spin-off"
+        # No cash position expected (no cash flow)
+        cash_data = find_position(result, CashPosition)
+        assert cash_data is None

--- a/tests/importers/schwab/test_transaction_extractor.py
+++ b/tests/importers/schwab/test_transaction_extractor.py
@@ -517,14 +517,14 @@ class TestSchwabTransactionExtractor:
         assert cash_stock_entry.balance == Decimal("-22.50")
         assert cash_stock_entry.name == "Cash flow for Tax Withholding JNJ"
 
-    def test_action_nra_tax_adj_positive(self): 
+    def test_action_nra_tax_adj_positive(self):
         extractor = create_extractor()
         data = {
             "FromDate": "01/01/2024", "ToDate": "12/31/2024",
             "BrokerageTransactions": [{
                 "Date": "10/01/2024", "Action": "NRA Tax Adj", "Symbol": "MSFT",
-                "Description": "TAX ADJUSTMENT RECEIVED", 
-                "Amount": "$5.00" 
+                "Description": "TAX ADJUSTMENT RECEIVED",
+                "Amount": "$5.00"
             }]
         }
         result = run_extraction_test(extractor, data, 2) # MSFT + Cash
@@ -542,7 +542,10 @@ class TestSchwabTransactionExtractor:
         assert len(payments) == 1
         payment = payments[0]
         assert payment.amount == Decimal("5.00")
-        assert payment.grossRevenueB == Decimal("5.00") 
+        # Positive amount = withholding reversal, recorded as negative nonRecoverableTax.
+        assert payment.grossRevenueB is None
+        assert payment.nonRecoverableTax == Decimal("-5.00")
+        assert payment.nonRecoverableTaxAmountOriginal == Decimal("-5.00")
         assert payment.name is not None
         assert payment.name == "NRA Tax Adj"
         
@@ -1049,7 +1052,7 @@ class TestSchwabTransactionExtractor:
         assert stock.name == "Stock Plan Activity"
 
     def test_action_tax_reversal(self):
-        """Tax Reversal with positive amount generates SecurityPayment + cash mutation (like NRA Tax Adj positive)."""
+        """Tax Reversal with positive amount records a negative nonRecoverableTax (offsetting prior withholding)."""
         extractor = create_extractor()
         data = {
             "FromDate": "01/01/2024", "ToDate": "12/31/2024",
@@ -1075,8 +1078,9 @@ class TestSchwabTransactionExtractor:
         assert len(payments) == 1
         payment = payments[0]
         assert payment.amount == Decimal("11.20")
-        assert payment.grossRevenueB == Decimal("11.20")
-        assert payment.nonRecoverableTax is None
+        assert payment.grossRevenueB is None
+        assert payment.nonRecoverableTax == Decimal("-11.20")
+        assert payment.nonRecoverableTaxAmountOriginal == Decimal("-11.20")
         assert payment.name == "Tax Reversal"
 
         cash_pos, cash_stocks, _ = cash_data
@@ -1333,7 +1337,7 @@ class TestSchwabTransactionExtractor:
             assert payment.broker_label_original == action_str
 
     def test_action_capital_gain_distributions(self):
-        """Short Term Cap Gain and Long Term Cap Gain create SecurityPayment with name 'Capital Gain'."""
+        """Cap-gain distributions create only a cash mutation (not taxable in Switzerland)."""
         extractor = create_extractor()
         data = {
             "FromDate": "01/01/2024", "ToDate": "12/31/2024",
@@ -1348,21 +1352,25 @@ class TestSchwabTransactionExtractor:
                 },
             ]
         }
-        result = run_extraction_test(extractor, data, 3)  # 2 SecurityPositions + 1 CashPosition
+        # Cap-gain distributions are not taxable income in CH; no SecurityPayment
+        # is generated, so the security positions have no stocks/payments and
+        # only the aggregated CashPosition appears in the output.
+        result = run_extraction_test(extractor, data, 1)
         assert result is not None
 
-        for symbol, action_str, amount in [("MSFT", "Short Term Cap Gain", "100.00"),
-                                           ("GOOG", "Long Term Cap Gain", "200.00")]:
-            sec_data = find_position(result, SecurityPosition, symbol)
-            assert sec_data is not None, f"SecurityPosition for {symbol} not found"
-            pos, stocks, payments = sec_data
-            assert isinstance(pos, SecurityPosition)
-            assert not stocks
-            assert payments is not None and len(payments) == 1
-            payment = payments[0]
-            assert payment.name == "Capital Gain", f"Payment name for {action_str} should be 'Capital Gain'"
-            assert payment.broker_label_original == action_str
-            assert payment.grossRevenueB == Decimal(amount)
+        cash_data = find_position(result, CashPosition)
+        assert cash_data is not None
+        cash_pos, cash_stocks, cash_payments = cash_data
+        assert isinstance(cash_pos, CashPosition)
+        assert cash_payments is None
+        assert cash_stocks is not None
+        assert sorted(s.quantity for s in cash_stocks) == [Decimal("100.00"), Decimal("200.00")]
+        names = {s.name for s in cash_stocks}
+        assert "Cash in for Short Term Cap Gain MSFT" in names
+        assert "Cash in for Long Term Cap Gain GOOG" in names
+
+        for symbol in ("MSFT", "GOOG"):
+            assert find_position(result, SecurityPosition, symbol) is None
 
     def test_action_cash_transfer_variants(self):
         """Misc Cash Entry, Service Fee, Wire Funds, Wire Sent, Funds Received, Visa Purchase, MoneyLink Deposit, Wire Funds Received are all cash-only."""

--- a/tests/importers/schwab/test_transaction_extractor.py
+++ b/tests/importers/schwab/test_transaction_extractor.py
@@ -1294,3 +1294,40 @@ class TestSchwabTransactionExtractor:
             assert payment.name == "Dividend", f"Payment name for {action_str} should be 'Dividend'"
             assert payment.broker_label_original == action_str
             assert payment.grossRevenueB == Decimal(amount)
+
+    def test_action_tax_withholding_variants(self):
+        """NRA Withholding, Foreign Tax Paid, and IRS Withhold Adj map to the tax withholding branch."""
+        extractor = create_extractor()
+        data = {
+            "FromDate": "01/01/2024", "ToDate": "12/31/2024",
+            "BrokerageTransactions": [
+                {
+                    "Date": "03/15/2024", "Action": "NRA Withholding", "Symbol": "MSFT",
+                    "Description": "NRA WITHHOLDING", "Amount": "-$10.00"
+                },
+                {
+                    "Date": "06/15/2024", "Action": "Foreign Tax Paid", "Symbol": "GOOG",
+                    "Description": "FOREIGN TAX PAID", "Amount": "-$20.00"
+                },
+                {
+                    "Date": "09/15/2024", "Action": "IRS Withhold Adj", "Symbol": "AAPL",
+                    "Description": "IRS WITHHOLDING ADJ", "Amount": "-$5.00"
+                },
+            ]
+        }
+        result = run_extraction_test(extractor, data, 4)  # 3 SecurityPositions + 1 CashPosition
+        assert result is not None
+
+        for symbol, action_str, amount in [("MSFT", "NRA Withholding", "-10.00"),
+                                           ("GOOG", "Foreign Tax Paid", "-20.00"),
+                                           ("AAPL", "IRS Withhold Adj", "-5.00")]:
+            sec_data = find_position(result, SecurityPosition, symbol)
+            assert sec_data is not None, f"SecurityPosition for {symbol} not found"
+            pos, stocks, payments = sec_data
+            assert isinstance(pos, SecurityPosition)
+            assert not stocks
+            assert payments is not None and len(payments) == 1
+            payment = payments[0]
+            assert payment.nonRecoverableTax == abs(Decimal(amount)), f"nonRecoverableTax for {action_str} should be set"
+            assert payment.grossRevenueB is None
+            assert payment.broker_label_original == action_str

--- a/tests/importers/schwab/test_transaction_extractor.py
+++ b/tests/importers/schwab/test_transaction_extractor.py
@@ -1193,3 +1193,42 @@ class TestSchwabTransactionExtractor:
         stock = stocks[0]
         assert stock.quantity == Decimal("-5000.00")
         assert "MoneyLink Transfer" in stock.name
+
+    def test_action_bond_interest(self):
+        """Bond Interest creates a SecurityPayment on the CUSIP position and a cash mutation."""
+        extractor = create_extractor()
+        data = {
+            "FromDate": "01/01/2023", "ToDate": "12/31/2023",
+            "BrokerageTransactions": [{
+                "Date": "03/15/2023", "Action": "Bond Interest", "Symbol": "912828YW8",
+                "Description": "US TREASURY NOTE", "Amount": "$500.00"
+            }]
+        }
+        result = run_extraction_test(extractor, data, 2)  # SecurityPosition for CUSIP + CashPosition
+        assert result is not None
+        bond_data = find_position(result, SecurityPosition, "912828YW8")
+        cash_data = find_position(result, CashPosition)
+        assert bond_data is not None
+        assert cash_data is not None
+
+        pos, stocks, payments = bond_data
+        assert isinstance(pos, SecurityPosition)
+        assert pos.symbol == "912828YW8"
+        assert not stocks
+        assert payments is not None
+        assert len(payments) == 1
+        payment = payments[0]
+        assert payment.paymentDate == date(2023, 3, 15)
+        assert payment.amount == Decimal("500.00")
+        assert payment.grossRevenueB == Decimal("500.00")
+        assert payment.name == "Bond Interest"
+        assert payment.broker_label_original == "Bond Interest"
+        assert payment.quantity == UNINITIALIZED_QUANTITY
+
+        cash_pos, cash_stocks, cash_payments = cash_data
+        assert isinstance(cash_pos, CashPosition)
+        assert cash_payments is None
+        assert cash_stocks is not None
+        assert len(cash_stocks) == 1
+        assert cash_stocks[0].quantity == Decimal("500.00")
+        assert cash_stocks[0].name == "Cash in for Bond Interest 912828YW8"

--- a/tests/importers/schwab/test_transaction_extractor.py
+++ b/tests/importers/schwab/test_transaction_extractor.py
@@ -1331,3 +1331,35 @@ class TestSchwabTransactionExtractor:
             assert payment.nonRecoverableTax == abs(Decimal(amount)), f"nonRecoverableTax for {action_str} should be set"
             assert payment.grossRevenueB is None
             assert payment.broker_label_original == action_str
+
+    def test_action_capital_gain_distributions(self):
+        """Short Term Cap Gain and Long Term Cap Gain create SecurityPayment with name 'Capital Gain'."""
+        extractor = create_extractor()
+        data = {
+            "FromDate": "01/01/2024", "ToDate": "12/31/2024",
+            "BrokerageTransactions": [
+                {
+                    "Date": "03/15/2024", "Action": "Short Term Cap Gain", "Symbol": "MSFT",
+                    "Description": "MICROSOFT CORP", "Amount": "$100.00"
+                },
+                {
+                    "Date": "06/15/2024", "Action": "Long Term Cap Gain", "Symbol": "GOOG",
+                    "Description": "ALPHABET INC", "Amount": "$200.00"
+                },
+            ]
+        }
+        result = run_extraction_test(extractor, data, 3)  # 2 SecurityPositions + 1 CashPosition
+        assert result is not None
+
+        for symbol, action_str, amount in [("MSFT", "Short Term Cap Gain", "100.00"),
+                                           ("GOOG", "Long Term Cap Gain", "200.00")]:
+            sec_data = find_position(result, SecurityPosition, symbol)
+            assert sec_data is not None, f"SecurityPosition for {symbol} not found"
+            pos, stocks, payments = sec_data
+            assert isinstance(pos, SecurityPosition)
+            assert not stocks
+            assert payments is not None and len(payments) == 1
+            payment = payments[0]
+            assert payment.name == "Capital Gain", f"Payment name for {action_str} should be 'Capital Gain'"
+            assert payment.broker_label_original == action_str
+            assert payment.grossRevenueB == Decimal(amount)


### PR DESCRIPTION
## Summary

Expands the Schwab JSON importer to handle 27 additional `Action` strings, inspired by cross-referencing with [KapJI/capital-gains-calculator](https://github.com/KapJI/capital-gains-calculator) and its sample data.

New types added (one commit each):

- **Dividend-like**: `Tax Reversal`, `Qualified Dividend`, `Cash Dividend`, `Non-Qualified Div`, `Special Qual Div`, `Div Adjustment`, `Bond Interest`
- **Tax withholding variants**: `NRA Withholding`, `Foreign Tax Paid`, `IRS Withhold Adj`
- **Capital gain distributions**: `Short Term Cap Gain`, `Long Term Cap Gain`
- **Cash transfers**: `MoneyLink Transfer`, `MoneyLink Adj`, `MoneyLink Deposit`, `Misc Cash Entry`, `Service Fee`, `Wire Funds`, `Wire Sent`, `Wire Funds Received`, `Funds Received`, `Visa Purchase`, `ADR Mgmt Fee`, `Adjustment`
- **Corporate actions**: `Spin-off`, `Cash Merger` (+ `Cash Merger Adj`), `Full Redemption` (+ `Full Redemption Adj`)

Also adds a reference to the KapJI project in the README Related projects section.

## Test plan

- [x] `pytest tests/importers/schwab/test_transaction_extractor.py` — 50 passed, each new type covered by a dedicated test
- [x] `pytest tests/` — full suite: 686 passed, 6 skipped