### PR TITLE
Allow filtering statements by contract id

### DIFF
--- a/scripts/filter_ibflex_xml.py
+++ b/scripts/filter_ibflex_xml.py
@@ -24,27 +24,27 @@ def local_name(tag: str) -> str:
     return tag
 
 
-def normalize_isin(value: str | None) -> str:
+def normalize_id(value: str | None) -> str:
     if not value:
         return ""
     return value.strip().upper()
 
 
-def parse_isins(raw_values: list[str]) -> set[str]:
-    isins: set[str] = set()
+def parse_filter_ids(raw_values: list[str]) -> set[str]:
+    filter_ids: set[str] = set()
     for raw_value in raw_values:
         for token in raw_value.split(","):
-            normalized = normalize_isin(token)
+            normalized = normalize_id(token)
             if normalized:
-                isins.add(normalized)
-    return isins
+                filter_ids.add(normalized)
+    return filter_ids
 
 
 def element_matches_isin(element: ET._Element, target_isins: set[str]) -> bool:
-    isin = normalize_isin(element.get("isin"))
-    security_id = normalize_isin(element.get("securityID"))
+    isin = normalize_id(element.get("isin"))
+    security_id = normalize_id(element.get("securityID"))
     security_id_type = (element.get("securityIDType") or "").strip().upper()
-    underlying_security_id = normalize_isin(element.get("underlyingSecurityID"))
+    underlying_security_id = normalize_id(element.get("underlyingSecurityID"))
 
     if isin and isin in target_isins:
         return True
@@ -55,7 +55,7 @@ def element_matches_isin(element: ET._Element, target_isins: set[str]) -> bool:
     return False
 
 
-def collect_linked_conids(statement: ET._Element, target_isins: set[str]) -> set[str]:
+def collect_linked_conids(statement: ET._Element, target_isins: set[str], target_conids: set[str]) -> set[str]:
     linked_conids: set[str] = set()
     for element in statement.iter():
         if not isinstance(element.tag, str):
@@ -66,8 +66,10 @@ def collect_linked_conids(statement: ET._Element, target_isins: set[str]) -> set
             conid = (element.get(attribute_name) or "").strip()
             if conid:
                 linked_conids.add(conid)
-    return linked_conids
 
+    # Include explicitly specified contract IDs
+    linked_conids.update(target_conids)
+    return linked_conids
 
 def element_matches_targets(
     element: ET._Element,
@@ -104,6 +106,10 @@ def prune_non_matching_descendants(
         if not element_matches_targets(child, target_isins, linked_conids) and not has_element_children:
             container.remove(child)
 
+def sanitize_statement_information(statement: ET._Element) -> None:
+    for name, value in ACCOUNT_INFO_ANONYMIZED_VALUES.items():
+        if statement.get(name) is not None:
+            statement.set(name, value)
 
 def sanitize_account_information(statement: ET._Element) -> None:
     account_information = None
@@ -129,8 +135,10 @@ def sanitize_account_information(statement: ET._Element) -> None:
     account_information.attrib.update(allowed_attributes)
 
 
-def filter_statement(statement: ET._Element, target_isins: set[str]) -> None:
-    linked_conids = collect_linked_conids(statement, target_isins)
+def filter_statement(statement: ET._Element, target_isins: set[str], target_conids: set[str]) -> None:
+    linked_conids = collect_linked_conids(statement, target_isins, target_conids)
+
+    sanitize_statement_information(statement)
 
     for child in list(statement):
         if not isinstance(child.tag, str):
@@ -156,8 +164,12 @@ def main() -> int:
     parser.add_argument(
         "--isins",
         nargs="+",
-        required=True,
         help="ISINs to keep (space and/or comma separated).",
+    )
+    parser.add_argument(
+        "--conids",
+        nargs="+",
+        help="Contract IDs to keep (space and/or comma separated).",
     )
     parser.add_argument(
         "--log-level",
@@ -169,13 +181,19 @@ def main() -> int:
 
     logging.basicConfig(level=getattr(logging, args.log_level), format="%(levelname)s: %(message)s")
 
-    target_isins = parse_isins(args.isins)
-    if not target_isins:
-        logging.error("No valid ISINs were provided.")
+    if args.isins is None and args.conids is None:
+        logging.error("At least one of --isins or --conids must be provided.")
         return 1
 
-    logging.info("Keeping %s ISIN(s): %s", len(target_isins), sorted(target_isins))
+    target_isins = parse_filter_ids(args.isins) if args.isins else set()
+    target_conids = parse_filter_ids(args.conids) if args.conids else set()
 
+    if not target_isins and not target_conids:
+        logging.error("No valid ISINs or Contract IDs were provided.")
+        return 1
+
+    logging.info("Keeping %s ISIN(s): %s / %s Contract ID(s): %s", len(target_isins), sorted(target_isins), len(target_conids), sorted(target_conids))
+    
     try:
         parser = ET.XMLParser(remove_blank_text=True)
         tree = ET.parse(args.input_file, parser)
@@ -196,7 +214,7 @@ def main() -> int:
 
     for index, statement in enumerate(statements, start=1):
         logging.info("Filtering FlexStatement %s/%s", index, len(statements))
-        filter_statement(statement, target_isins)
+        filter_statement(statement, target_isins, target_conids)
 
     output_path = Path(args.output_file)
     output_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/scripts/test_filter_ibflex_xml.py
+++ b/tests/scripts/test_filter_ibflex_xml.py
@@ -6,7 +6,7 @@ import lxml.etree as ET
 SCRIPTS_DIR = Path(__file__).parent.parent.parent / "scripts"
 sys.path.insert(0, str(SCRIPTS_DIR))
 
-from filter_ibflex_xml import filter_statement, parse_isins
+from filter_ibflex_xml import filter_statement, parse_filter_ids
 
 SAMPLE_IBFLEX_XML = """<?xml version=\"1.0\" encoding=\"UTF-8\"?>
 <FlexQueryResponse queryName=\"Annual Tax Report\" type=\"AF\">
@@ -37,7 +37,8 @@ def run_filter_script(tmp_path: Path, *extra_args: str) -> Path:
     output_file = tmp_path / "output.xml"
     input_file.write_text(SAMPLE_IBFLEX_XML, encoding="utf-8")
 
-    target_isins = parse_isins(["US0000000001"])
+    target_isins = parse_filter_ids(["US0000000001"])
+    target_conids = set()  # No conids specified, so only ISIN-based filtering applies
 
     parser = ET.XMLParser(remove_blank_text=True)
     tree = ET.parse(str(input_file), parser)
@@ -45,12 +46,31 @@ def run_filter_script(tmp_path: Path, *extra_args: str) -> Path:
 
     for statement in root.iter():
         if isinstance(statement.tag, str) and statement.tag.endswith("FlexStatement"):
-            filter_statement(statement, target_isins)
+            filter_statement(statement, target_isins, target_conids)
 
     tree.write(str(output_file), encoding="UTF-8", xml_declaration=True, pretty_print=True)
     assert output_file.exists()
     return output_file
 
+def run_filter_script_conids(tmp_path: Path, *extra_args: str) -> Path:
+    input_file = tmp_path / "input.xml"
+    output_file = tmp_path / "output.xml"
+    input_file.write_text(SAMPLE_IBFLEX_XML, encoding="utf-8")
+
+    target_isins = set()  # No ISINs specified, so only conid-based filtering applies
+    target_conids = parse_filter_ids(["1,3"])  # Specify conids to filter by
+
+    parser = ET.XMLParser(remove_blank_text=True)
+    tree = ET.parse(str(input_file), parser)
+    root = tree.getroot()
+
+    for statement in root.iter():
+        if isinstance(statement.tag, str) and statement.tag.endswith("FlexStatement"):
+            filter_statement(statement, target_isins, target_conids)
+
+    tree.write(str(output_file), encoding="UTF-8", xml_declaration=True, pretty_print=True)
+    assert output_file.exists()
+    return output_file
 
 def test_non_selected_isins_are_removed_from_minimal_ibflex_xml(tmp_path):
     output_file = run_filter_script(tmp_path)
@@ -68,6 +88,16 @@ def test_non_selected_isins_are_removed_from_minimal_ibflex_xml(tmp_path):
     }
     assert output_isins == {"US0000000001"}
 
+def test_non_selected_conids_are_removed_from_minimal_ibflex_xml(tmp_path):
+    output_file = run_filter_script_conids(tmp_path)
+    tree = ET.parse(str(output_file))
+
+    assert tree.xpath("count(.//Trade[@conid='1'])") == 1.0
+    assert tree.xpath("count(.//Trade[@conid='3'])") == 1.0
+    assert tree.xpath("count(.//Trade[@conid='2'])") == 0.0
+
+    assert tree.xpath("count(.//CashTransaction[@conid='3'])") == 1.0
+    assert tree.xpath("count(.//CashTransaction[@conid='2'])") == 0.0
 
 def test_account_information_keeps_only_allowed_attributes(tmp_path):
     output_file = run_filter_script(tmp_path)


### PR DESCRIPTION
Allow filtering by isin and/or contract id (conid).
- some products (e.g. futures) don't have an ISIN
- with many option transactions it's easier to filter by a few entries rather than add all entries for an underlying (filtered by isin)