### PR TITLE
Move payment variant validation into main processing loop

### DIFF
--- a/src/opensteuerauszug/calculate/kursliste_tax_value_calculator.py
+++ b/src/opensteuerauszug/calculate/kursliste_tax_value_calculator.py
@@ -558,25 +558,13 @@ class KurslisteTaxValueCalculator(MinimalTaxValueCalculator):
 
         payments = [p for p in kl_sec.payment if not p.deleted]
 
-        # Detect payments with multiple variants for the same event.
-        # The variant attribute on a payment means that only ONE of the distinct variant
-        # numbers should be applied (OR-choice, e.g. cash dividend vs. stock dividend).
-        # We have no mechanical way to make this choice, so we raise an error.
-        _variants_by_event: dict[date | None, set[int]] = {}
-        for _pay in payments:
-            if _pay.variant is None:
-                continue
-            _event_key = _pay.exDate or _pay.paymentDate
-            _variants_by_event.setdefault(_event_key, set()).add(_pay.variant)
-        for _event_key, _variants in _variants_by_event.items():
-            if len(_variants) > 1:
-                sec_ident = security.isin or security.securityName
-                raise NotImplementedError(
-                    f"Payment on {_event_key} for '{sec_ident}' has multiple variants "
-                    f"({sorted(_variants)}). Manual selection of a variant is required."
-                )
-
         result: List[SecurityPayment] = []
+
+        # Track variant numbers seen per event key so we can detect payments that
+        # represent an OR-choice (e.g. cash dividend vs. stock dividend). The check
+        # is woven into the main loop so it only considers payments that are
+        # actually processed (respecting the paymentDate and capitalGain filters).
+        variants_by_event: dict[date, set[int]] = {}
 
         stock = list(security.stock)
         if security.taxValue:
@@ -610,6 +598,20 @@ class KurslisteTaxValueCalculator(MinimalTaxValueCalculator):
                 continue
 
             reconciliation_date = pay.exDate or pay.paymentDate
+
+            # The variant attribute marks an OR-choice between mutually exclusive
+            # payment alternatives (e.g. cash dividend vs. stock dividend). If we
+            # encounter more than one distinct variant for the same event, there
+            # is no mechanical way to choose — surface this to the user.
+            if pay.variant is not None:
+                seen = variants_by_event.setdefault(reconciliation_date, set())
+                seen.add(pay.variant)
+                if len(seen) > 1:
+                    sec_ident = security.isin or security.securityName
+                    raise NotImplementedError(
+                        f"Payment on {reconciliation_date} for '{sec_ident}' has multiple variants "
+                        f"({sorted(seen)}). Manual selection of a variant is required."
+                    )
 
             # Warn if exDate is in the previous year (before the tax period)
             if pay.exDate and security.taxValue and security.taxValue.referenceDate:

--- a/tests/calculate/test_kursliste_tax_value_calculator.py
+++ b/tests/calculate/test_kursliste_tax_value_calculator.py
@@ -2430,6 +2430,12 @@ def test_compute_payments_single_variant_does_not_raise(kursliste_manager):
     Test that payments where every payment for an event shares the same single variant
     value do not raise an error (they all belong to the same chosen option).
     """
+    # computePayments flows all the way through the DA-1 lookup which calls
+    # accessor.get_da1_rate unconditionally; require the year's data to exist.
+    ensure_kursliste_year_available(
+        kursliste_manager, 2024, "test_compute_payments_single_variant_does_not_raise"
+    )
+
     provider = KurslisteExchangeRateProvider(kursliste_manager)
     calc = KurslisteTaxValueCalculator(mode=CalculationMode.FILL, exchange_rate_provider=provider)
 


### PR DESCRIPTION
## Summary
Refactored the payment variant validation logic to execute within the main payment processing loop instead of as a separate pre-check. This ensures variant conflicts are only detected for payments that are actually processed, respecting filters like `paymentDate` and `capitalGain`.

## Key Changes
- Moved variant conflict detection from a separate pre-processing block into the main payment iteration loop
- Changed `variants_by_event` dictionary key type from `date | None` to `date` to match the `reconciliation_date` variable used in the loop
- Updated variable naming for clarity (`_variants_by_event` → `variants_by_event`, `_pay` → `pay`, `_event_key` → `reconciliation_date`)
- Improved code comments to explain the OR-choice semantics and why the check is integrated into the main loop
- Fixed test setup to ensure required kursliste year data is available before running `computePayments`

## Implementation Details
The variant validation now occurs at the point where each payment is actually processed, allowing it to respect any filtering logic that may skip certain payments. This prevents false positives where variant conflicts might be reported for payments that wouldn't be included in the final result anyway.

https://claude.ai/code/session_01MtMPvmsmqTT3mCaZJSuhYe