### PR TITLE
Set dividend 0 for short stock

### DIFF
--- a/src/opensteuerauszug/calculate/kursliste_tax_value_calculator.py
+++ b/src/opensteuerauszug/calculate/kursliste_tax_value_calculator.py
@@ -759,6 +759,15 @@ class KurslisteTaxValueCalculator(MinimalTaxValueCalculator):
             amount = amount_per_unit * quantity
             chf_amount = chf_per_unit * quantity
 
+            if quantity < Decimal("0") and (amount < Decimal("0") or chf_amount < Decimal("0")):
+                logger.warning(
+                    f"Negative payment amount for {security.isin or security.securityName} on {pay.paymentDate}: {amount} {pay.currency}. "
+                    f"Position: {quantity} on record date {pay.exDate-timedelta(days=1)}. "
+                    "Please verify this payment manually. Negative dividends are not tax-deductible."
+                )
+                amount = Decimal("0")
+                chf_amount = Decimal("0")
+
             rate = pay.exchangeRate
             if rate is None and pay.paymentValueCHF != 0:
                 if pay.currency == "CHF":

--- a/src/opensteuerauszug/calculate/payment_reconciliation_calculator.py
+++ b/src/opensteuerauszug/calculate/payment_reconciliation_calculator.py
@@ -41,6 +41,7 @@ class _KurslisteAgg:
     allows_broker_above_kursliste: bool = False
     has_capped_payment: bool = False
     original_withholding_chf: Optional[Decimal] = None
+    short_stock: Optional[bool] = None
 
 
 class PaymentReconciliationCalculator:
@@ -247,6 +248,10 @@ class PaymentReconciliationCalculator:
                             f'W8-BEN. delta={w_diff} CHF.')
                 matched = not (div_diff or w_diff)
                 status = "match" if matched else "mismatch"
+                if kurs.short_stock and div_diff < Decimal("0") and not kurs.dividend_chf:
+                    matched = True
+                    status = "expected"
+                    note += " Short stock dividend set to 0."
             elif not has_kurs and has_broker:
                 note = "Broker payment has no Kursliste entry."
             elif has_kurs and not has_broker:
@@ -352,6 +357,9 @@ class PaymentReconciliationCalculator:
 
         if self._is_broker_above_kursliste_allowlisted(payment):
             agg.allows_broker_above_kursliste = True
+
+        if payment.quantity < Decimal("0"):
+            agg.short_stock = True
 
         # Detect payments that were already capped by WithholdingCapCalculator.
         if payment.withholding_capped:

--- a/tests/calculate/test_kursliste_tax_value_calculator.py
+++ b/tests/calculate/test_kursliste_tax_value_calculator.py
@@ -1882,6 +1882,48 @@ def test_compute_payments_skip_zero_quantity(kursliste_manager):
     # Should not generate any payments since quantity is zero on payment dates
     assert len(sec.payment) == 0
 
+def test_compute_payments_negative_quantity(kursliste_manager):
+    """
+    Test that payment value is set to 0 when the quantity of outstanding
+    securities is negative on the payment date.
+    """
+    provider = KurslisteExchangeRateProvider(kursliste_manager)
+    calc = KurslisteTaxValueCalculator(mode=CalculationMode.FILL, exchange_rate_provider=provider)
+
+    # Create a security with stock that is short on the payment date
+    sec = Security(
+        country="US",
+        securityName="Vanguard Total Stock Market ETF",
+        positionId=1,
+        currency="USD",
+        quotationType="PIECE",
+        securityCategory="FUND",
+        isin=ISINType("US9229087690"),
+        stock=[
+            SecurityStock(
+                referenceDate=date(2024, 3, 21),
+                mutation=True,
+                quotationType="PIECE",
+                quantity=Decimal("-100"),
+                balanceCurrency="USD",
+            ),
+            SecurityStock(
+                referenceDate=date(2024, 3, 22),
+                mutation=True,
+                quotationType="PIECE",
+                quantity=Decimal("100"),
+                balanceCurrency="USD",
+            ),
+        ],
+    )
+
+    calc._handle_Security(sec, "sec")
+    assert len(sec.payment) == 1
+    payment = sec.payment[0]
+    assert payment.quantity == Decimal("-100")
+    assert payment.amount == Decimal("0")
+    assert payment.amountPerUnit > Decimal("0")
+
 
 def test_compute_payments_capital_gain_scenario(kursliste_manager):
     """

--- a/tests/calculate/test_payment_reconciliation_calculator.py
+++ b/tests/calculate/test_payment_reconciliation_calculator.py
@@ -836,6 +836,60 @@ def test_explicit_zero_kursliste_entry_with_broker_cash_is_mismatch_without_allo
     assert row.matched is False
 
 
+def test_short_stock_zero_payment_is_expected():
+    statement = TaxStatement(
+        minorVersion=2,
+        listOfSecurities=ListOfSecurities(
+            depot=[
+                Depot(
+                    depotNumber=DepotNumber("D1"),
+                    security=[
+                        Security(
+                            positionId=1,
+                            country="US",
+                            currency="USD",
+                            quotationType="PIECE",
+                            securityCategory="SHARE",
+                            securityName="VT",
+                            payment=[
+                                SecurityPayment(
+                                    paymentDate=date(2025, 12, 23),
+                                    quotationType="PIECE",
+                                    quantity=Decimal("-1"),
+                                    amountCurrency="USD",
+                                    amount=Decimal("0"),
+                                    amountPerUnit=Decimal("25"),
+                                    exchangeRate=Decimal("1"),
+                                    grossRevenueB=Decimal("0"),
+                                    withHoldingTaxClaim=Decimal("0"),
+                                    kursliste=True,
+                                )
+                            ],
+                            broker_payments=[
+                                SecurityPayment(
+                                    paymentDate=date(2025, 12, 23),
+                                    quotationType="PIECE",
+                                    quantity=Decimal("-1"),
+                                    amountCurrency="USD",
+                                    amount=Decimal("-25"),
+                                    name="Dividend",
+                                )
+                            ],
+                        )
+                    ],
+                )
+            ]
+        ),
+    )
+
+    result = PaymentReconciliationCalculator().calculate(statement)
+    row = result.payment_reconciliation_report.rows[0]
+    assert row.status == "expected"
+    assert row.matched is True
+    assert row.note is not None
+    assert "Short stock" in row.note
+
+
 # --------------------------------------------------------------------------- #
 #  Issue #308: Withholding-tax cap for (Q)-signed payments
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Negative dividends (payment in lieu) due to short stock on record date are not tax deductible and cannot be treated as fees or interest payment (according to various court rulings). 
Set dividend to 0 but leave quantity and amount per unit as is (tax software efisc TG does the same when manually entering negative qty)