### PR TITLE
Lay out importers/common helpers for cross-broker reuse (no behaviour change)

### DIFF
--- a/src/opensteuerauszug/importers/common/__init__.py
+++ b/src/opensteuerauszug/importers/common/__init__.py
@@ -10,6 +10,7 @@ composed into the importers rather than imposed via inheritance.
 """
 
 from .parsing import to_decimal
+from .security_name import SecurityNameRegistry
 from .stock_aggregation import aggregate_mutations
 from .types import CashPositionData, SecurityNameMetadata, SecurityPositionData
 
@@ -17,6 +18,7 @@ __all__ = [
     "CashPositionData",
     "SecurityPositionData",
     "SecurityNameMetadata",
+    "SecurityNameRegistry",
     "aggregate_mutations",
     "to_decimal",
 ]

--- a/src/opensteuerauszug/importers/common/__init__.py
+++ b/src/opensteuerauszug/importers/common/__init__.py
@@ -1,0 +1,18 @@
+"""Shared helpers used by multiple broker importers.
+
+Importers historically re-implemented similar glue (TypedDict aggregators,
+decimal parsing, stock-aggregation, name/canton/client building).  This
+package collects the reusable pieces so each importer can focus on the
+extraction that is actually broker-specific.
+
+The helpers here are intentionally plain functions or small value objects,
+composed into the importers rather than imposed via inheritance.
+"""
+
+from .types import CashPositionData, SecurityNameMetadata, SecurityPositionData
+
+__all__ = [
+    "CashPositionData",
+    "SecurityPositionData",
+    "SecurityNameMetadata",
+]

--- a/src/opensteuerauszug/importers/common/__init__.py
+++ b/src/opensteuerauszug/importers/common/__init__.py
@@ -9,10 +9,14 @@ The helpers here are intentionally plain functions or small value objects,
 composed into the importers rather than imposed via inheritance.
 """
 
+from .parsing import to_decimal
+from .stock_aggregation import aggregate_mutations
 from .types import CashPositionData, SecurityNameMetadata, SecurityPositionData
 
 __all__ = [
     "CashPositionData",
     "SecurityPositionData",
     "SecurityNameMetadata",
+    "aggregate_mutations",
+    "to_decimal",
 ]

--- a/src/opensteuerauszug/importers/common/__init__.py
+++ b/src/opensteuerauszug/importers/common/__init__.py
@@ -9,6 +9,13 @@ The helpers here are intentionally plain functions or small value objects,
 composed into the importers rather than imposed via inheritance.
 """
 
+from .client import (
+    build_client,
+    is_nonempty_string,
+    parse_swiss_canton,
+    resolve_first_last_name,
+    split_full_name,
+)
 from .parsing import to_decimal
 from .security_name import SecurityNameRegistry
 from .stock_aggregation import aggregate_mutations
@@ -20,5 +27,10 @@ __all__ = [
     "SecurityNameMetadata",
     "SecurityNameRegistry",
     "aggregate_mutations",
+    "build_client",
+    "is_nonempty_string",
+    "parse_swiss_canton",
+    "resolve_first_last_name",
+    "split_full_name",
     "to_decimal",
 ]

--- a/src/opensteuerauszug/importers/common/__init__.py
+++ b/src/opensteuerauszug/importers/common/__init__.py
@@ -17,6 +17,7 @@ from .client import (
     split_full_name,
 )
 from .parsing import to_decimal
+from .payments import apply_withholding_tax_fields, build_security_payment
 from .security_name import SecurityNameRegistry
 from .stock_aggregation import aggregate_mutations
 from .types import CashPositionData, SecurityNameMetadata, SecurityPositionData
@@ -27,7 +28,9 @@ __all__ = [
     "SecurityNameMetadata",
     "SecurityNameRegistry",
     "aggregate_mutations",
+    "apply_withholding_tax_fields",
     "build_client",
+    "build_security_payment",
     "is_nonempty_string",
     "parse_swiss_canton",
     "resolve_first_last_name",

--- a/src/opensteuerauszug/importers/common/client.py
+++ b/src/opensteuerauszug/importers/common/client.py
@@ -1,0 +1,110 @@
+"""Shared helpers for building the Client object and canton assignment.
+
+Broker statements expose holder names in a variety of shapes: sometimes
+as separate first/last, sometimes as a single "Firstname Lastname"
+string, sometimes as a looser "accountHolderName" field.  And the canton
+on the eCH-0196 TaxStatement is typically embedded in an address string
+like ``"CH-ZH"`` or comes straight from the user's config.
+
+This module provides three small, pure helpers that each importer can
+compose.  No inheritance, no hidden state.
+"""
+
+from typing import Optional, Tuple, cast, get_args
+
+from opensteuerauszug.model.ech0196 import (
+    CantonAbbreviation,
+    Client,
+    ClientNumber,
+)
+
+
+def is_nonempty_string(value: object) -> bool:
+    """True if *value* is a non-empty / non-whitespace string."""
+    return value is not None and isinstance(value, str) and bool(value.strip())
+
+
+def split_full_name(value: object) -> Tuple[Optional[str], str]:
+    """Split ``"First Middle Last"`` into ``("First", "Middle Last")``.
+
+    Single-token inputs return ``(None, <token>)`` so callers can still
+    place the value in ``lastName`` if that is all they have.
+    """
+    parts = str(value).strip().split()
+    if len(parts) > 1:
+        return parts[0], " ".join(parts[1:])
+    return None, str(value).strip()
+
+
+def resolve_first_last_name(
+    *,
+    first_name: object = None,
+    last_name: object = None,
+    full_name: object = None,
+    account_holder_name: object = None,
+) -> Tuple[Optional[str], Optional[str]]:
+    """Pick the best first/last name pair from a set of candidates.
+
+    Precedence mirrors the existing importer logic:
+
+    1. Explicit first_name + last_name
+    2. Explicit first_name + split of full_name for the surname
+    3. Split of full_name
+    4. Split of account_holder_name
+    """
+    if is_nonempty_string(first_name) and is_nonempty_string(last_name):
+        return str(first_name).strip(), str(last_name).strip()
+    if is_nonempty_string(first_name) and is_nonempty_string(full_name):
+        _, surname = split_full_name(full_name)
+        return str(first_name).strip(), surname
+    if is_nonempty_string(full_name):
+        return split_full_name(full_name)
+    if is_nonempty_string(account_holder_name):
+        return split_full_name(account_holder_name)
+    return None, None
+
+
+def parse_swiss_canton(value: object) -> Optional[CantonAbbreviation]:
+    """Return a validated CantonAbbreviation from loose input, or None.
+
+    Accepts values like ``"ZH"``, ``"zh"`` or an ``"CH-ZH"`` style
+    address string.  Returns ``None`` if the canton cannot be extracted
+    or is not a recognised abbreviation.
+    """
+    if value is None:
+        return None
+    raw = str(value).strip()
+    if not raw:
+        return None
+    candidate = raw
+    if "-" in raw:
+        parts = raw.split("-")
+        if len(parts) == 2 and parts[0].upper() == "CH":
+            candidate = parts[1]
+        else:
+            return None
+    candidate = candidate.strip().upper()
+    valid = get_args(CantonAbbreviation)
+    if candidate in valid:
+        return cast(CantonAbbreviation, candidate)
+    return None
+
+
+def build_client(
+    client_number: Optional[str],
+    first_name: Optional[str],
+    last_name: Optional[str],
+) -> Optional[Client]:
+    """Construct a ``Client`` from an id + name pair, or return None.
+
+    We require at minimum a client number; names are optional.  Callers
+    should treat ``None`` as "nothing authoritative to put on the
+    statement" and leave ``TaxStatement.client`` unset.
+    """
+    if not client_number:
+        return None
+    return Client(
+        clientNumber=ClientNumber(client_number),
+        firstName=first_name,
+        lastName=last_name,
+    )

--- a/src/opensteuerauszug/importers/common/parsing.py
+++ b/src/opensteuerauszug/importers/common/parsing.py
@@ -1,0 +1,33 @@
+"""Small parsing helpers shared by broker importers.
+
+These are all plain functions.  The aim is that any importer can
+compose them without having to derive from a base class.
+"""
+
+from decimal import Decimal, InvalidOperation
+
+
+def to_decimal(value: object | None, field_name: str, context: str) -> Decimal:
+    """Convert *value* to ``Decimal`` or raise ``ValueError`` with context.
+
+    Args:
+        value: The value to convert.  Typically a ``str``, ``int`` or
+            ``Decimal``; anything that ``Decimal(str(x))`` can parse.
+        field_name: Logical field the value came from (for error messages).
+        context: Free-form context such as ``"Trade AAPL"`` that is embedded
+            in the exception to help the user locate bad input rows.
+
+    Raises:
+        ValueError: if *value* is ``None`` or cannot be parsed as Decimal.
+    """
+    if value is None:
+        raise ValueError(
+            f"Cannot convert None to Decimal for field '{field_name}' in {context}"
+        )
+    try:
+        return Decimal(str(value))
+    except InvalidOperation:
+        raise ValueError(
+            f"Invalid value for Decimal conversion: '{value}' for field "
+            f"'{field_name}' in {context}"
+        )

--- a/src/opensteuerauszug/importers/common/payments.py
+++ b/src/opensteuerauszug/importers/common/payments.py
@@ -1,0 +1,77 @@
+"""Shared SecurityPayment construction helpers.
+
+Both the IBKR and Fidelity importers build a ``SecurityPayment`` from a
+small, fixed set of inputs: a date, a description, a currency, an
+amount, and a pair of flags (is this a withholding-tax event? is this a
+payment-in-lieu / securities-lending event?).
+
+The *classification* — whether a given broker row is a withholding event
+— differs per importer (ibflex enum vs Fidelity string), so we accept
+it as two booleans and let each importer decide.  No inheritance
+required.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+from opensteuerauszug.core.constants import UNINITIALIZED_QUANTITY
+from opensteuerauszug.model.ech0196 import SecurityPayment
+
+
+def apply_withholding_tax_fields(
+    payment: SecurityPayment,
+    amount: Decimal,
+    currency: str,
+) -> None:
+    """Populate the withholding-tax fields of *payment* from *amount*.
+
+    The sign and currency convention is preserved across importers:
+      * amount < 0 in CHF         → ``withHoldingTaxClaim = |amount|``
+      * amount < 0 in non-CHF     → ``nonRecoverableTaxAmountOriginal = |amount|``
+      * amount > 0 (reversal)     → ``nonRecoverableTaxAmountOriginal = -amount``
+
+    Callers must only invoke this when they have already classified the
+    row as a withholding event.
+    """
+    if amount < 0:
+        if currency == "CHF":
+            payment.withHoldingTaxClaim = abs(amount)
+        else:
+            payment.nonRecoverableTaxAmountOriginal = abs(amount)
+    elif amount > 0:
+        payment.nonRecoverableTaxAmountOriginal = -amount
+
+
+def build_security_payment(
+    *,
+    payment_date: date,
+    description: str,
+    currency: str,
+    amount: Decimal,
+    broker_label: str,
+    is_withholding: bool = False,
+    is_securities_lending: bool = False,
+) -> SecurityPayment:
+    """Build a ``SecurityPayment`` and apply the common post-processing.
+
+    ``is_withholding`` triggers :func:`apply_withholding_tax_fields`.
+    ``is_securities_lending`` sets ``securitiesLending=True`` (used by
+    IBKR ``PAYMENTINLIEU`` and Fidelity ``Cash In Lieu``).
+
+    ``broker_label`` is stored on ``SecurityPayment.broker_label_original``
+    for later traceability / reconciliation.
+    """
+    payment = SecurityPayment(
+        paymentDate=payment_date,
+        name=description,
+        amountCurrency=currency,
+        amount=amount,
+        quotationType="PIECE",
+        quantity=UNINITIALIZED_QUANTITY,
+        broker_label_original=broker_label,
+    )
+    if is_securities_lending:
+        payment.securitiesLending = True
+    if is_withholding:
+        apply_withholding_tax_fields(payment, amount, currency)
+    return payment

--- a/src/opensteuerauszug/importers/common/security_name.py
+++ b/src/opensteuerauszug/importers/common/security_name.py
@@ -1,0 +1,65 @@
+"""Best-name-wins registry for security display names.
+
+Broker statements describe the same security in many places (trades,
+open positions, dividend postings).  Importers want to use the most
+authoritative one.  Each importer historically re-implemented the same
+defaultdict-based bookkeeping around a ``(best_name, priority)`` tuple.
+
+``SecurityNameRegistry`` is a small value object that encapsulates that
+bookkeeping so importers can compose it in instead of copying the code.
+"""
+
+from collections import defaultdict
+from typing import Iterator, Tuple
+
+from opensteuerauszug.model.position import SecurityPosition
+
+from .types import SecurityNameMetadata
+
+
+class SecurityNameRegistry:
+    """Tracks the highest-priority name seen for each SecurityPosition.
+
+    Priorities are caller-defined; higher wins, ties keep the existing
+    entry.  Typical conventions used by broker importers:
+
+    * 10 — OpenPositions snapshot (authoritative)
+    * 8  — Trade rows
+    * 5  — Transfers
+    * 0  — CashTransaction descriptions (fallback only)
+
+    The class only records names; resolving the final display string
+    (including fallbacks to description or symbol) is the importer's
+    responsibility via :meth:`resolve`.
+    """
+
+    def __init__(self) -> None:
+        self._entries: defaultdict[SecurityPosition, SecurityNameMetadata] = defaultdict(
+            lambda: {"best_name": None, "priority": -1}
+        )
+
+    def update(self, position: SecurityPosition, name: str, priority: int) -> None:
+        """Record *name* for *position* if *priority* beats the current best."""
+        entry = self._entries[position]
+        if priority > entry["priority"]:
+            entry["best_name"] = name
+            entry["priority"] = priority
+
+    def best(self, position: SecurityPosition) -> str | None:
+        """Return the best name recorded so far, or ``None`` if none."""
+        return self._entries[position]["best_name"]
+
+    def resolve(self, position: SecurityPosition) -> str:
+        """Return the best name, falling back to description then symbol."""
+        name = self.best(position)
+        if name:
+            return name
+        if position.description:
+            return position.description
+        return position.symbol
+
+    def __contains__(self, position: SecurityPosition) -> bool:
+        return position in self._entries
+
+    def items(self) -> Iterator[Tuple[SecurityPosition, SecurityNameMetadata]]:
+        return iter(self._entries.items())

--- a/src/opensteuerauszug/importers/common/stock_aggregation.py
+++ b/src/opensteuerauszug/importers/common/stock_aggregation.py
@@ -1,0 +1,67 @@
+"""Aggregate successive same-day, same-order mutations.
+
+Multiple partial fills of a single order appear as separate ``SecurityStock``
+entries.  Importers want them collapsed into one entry per (date, orderId,
+side) so the resulting statement reads cleanly.
+
+This is a pure list-to-list transformation; importers call it on the
+per-position stock list just before post-processing.
+"""
+
+from typing import List
+
+from opensteuerauszug.model.ech0196 import SecurityStock
+
+
+def aggregate_mutations(stocks: List[SecurityStock]) -> List[SecurityStock]:
+    """Merge runs of same-side mutations sharing date + orderId + currency.
+
+    Preserves input order; non-mutation balance entries pass through
+    unchanged.  When mutations are merged the combined quantity is the
+    sum, and the combined unit price is the quantity-weighted average if
+    prices differed.
+    """
+    aggregated: List[SecurityStock] = []
+    pending: SecurityStock | None = None
+
+    for stock in stocks:
+        if stock.mutation:
+            if (
+                pending
+                and pending.referenceDate == stock.referenceDate
+                and pending.orderId == stock.orderId
+                and pending.balanceCurrency == stock.balanceCurrency
+                and pending.quotationType == stock.quotationType
+                # same sign => same side (buy vs sell)
+                and (pending.quantity * stock.quantity) > 0
+            ):
+                total_quantity = pending.quantity + stock.quantity
+                if pending.unitPrice != stock.unitPrice:
+                    pending.unitPrice = (
+                        pending.quantity * pending.unitPrice
+                        + stock.quantity * stock.unitPrice
+                    ) / total_quantity
+                pending.quantity = total_quantity
+            else:
+                if pending:
+                    aggregated.append(pending)
+                pending = SecurityStock(
+                    referenceDate=stock.referenceDate,
+                    mutation=True,
+                    quantity=stock.quantity,
+                    unitPrice=stock.unitPrice,
+                    name=stock.name,
+                    orderId=stock.orderId,
+                    balanceCurrency=stock.balanceCurrency,
+                    quotationType=stock.quotationType,
+                )
+        else:
+            if pending:
+                aggregated.append(pending)
+                pending = None
+            aggregated.append(stock)
+
+    if pending:
+        aggregated.append(pending)
+
+    return aggregated

--- a/src/opensteuerauszug/importers/common/types.py
+++ b/src/opensteuerauszug/importers/common/types.py
@@ -1,0 +1,37 @@
+"""Accumulator TypedDicts shared by broker importers.
+
+Every importer builds up the same two per-position buckets while walking
+the broker's source data: a list of ``SecurityStock`` entries and a list
+of per-position payments.  Keeping the shapes in one place avoids the
+cross-importer imports that grew organically (e.g. the Fidelity importer
+previously reached into ``ibkr_importer`` for these).
+"""
+
+from typing import TypedDict
+
+from opensteuerauszug.model.ech0196 import (
+    BankAccountPayment,
+    SecurityPayment,
+    SecurityStock,
+)
+
+
+class SecurityPositionData(TypedDict):
+    """Per-security accumulator: stock entries and security-level payments."""
+
+    stocks: list[SecurityStock]
+    payments: list[SecurityPayment]
+
+
+class CashPositionData(TypedDict):
+    """Per-cash-bucket accumulator: stock entries and bank-account payments."""
+
+    stocks: list[SecurityStock]
+    payments: list[BankAccountPayment]
+
+
+class SecurityNameMetadata(TypedDict):
+    """Best-name tracking state for a single security position."""
+
+    best_name: str | None
+    priority: int

--- a/src/opensteuerauszug/importers/ibkr/ibkr_importer.py
+++ b/src/opensteuerauszug/importers/ibkr/ibkr_importer.py
@@ -1,6 +1,6 @@
 import os
 import logging
-from typing import Final, List, Any, Dict, Optional, Sequence, TypedDict, get_args, cast
+from typing import Final, List, Any, Dict, Optional, Sequence, get_args, cast
 from datetime import date, datetime, timedelta
 from decimal import Decimal, InvalidOperation
 from collections import defaultdict
@@ -17,6 +17,11 @@ from opensteuerauszug.model.ech0196 import (
 from opensteuerauszug.core.position_reconciler import PositionReconciler
 from opensteuerauszug.config.models import IbkrAccountSettings
 from opensteuerauszug.core.constants import UNINITIALIZED_QUANTITY
+from opensteuerauszug.importers.common import (
+    CashPositionData,
+    SecurityNameMetadata,
+    SecurityPositionData,
+)
 from opensteuerauszug.render.translations import get_text, Language, DEFAULT_LANGUAGE
 
 IBKR_ASSET_CATEGORY_TO_ECH_SECURITY_CATEGORY: Final[Dict[str, SecurityCategory]] = {
@@ -32,21 +37,6 @@ IBKR_ASSET_CATEGORY_TO_ECH_SECURITY_CATEGORY: Final[Dict[str, SecurityCategory]]
 import ibflex
 from ibflex.parser import FlexParserError
 from ibflex.enums import TradeType
-
-
-class SecurityPositionData(TypedDict):
-    stocks: list[SecurityStock]
-    payments: list[SecurityPayment]
-
-
-class CashPositionData(TypedDict):
-    stocks: list[SecurityStock]
-    payments: list[BankAccountPayment]
-
-
-class SecurityNameMetadata(TypedDict):
-    best_name: str | None
-    priority: int
 
 
 def is_summary_level(entry: object) -> bool:

--- a/src/opensteuerauszug/importers/ibkr/ibkr_importer.py
+++ b/src/opensteuerauszug/importers/ibkr/ibkr_importer.py
@@ -2,7 +2,7 @@ import os
 import logging
 from typing import Final, List, Any, Dict, Optional, Sequence, get_args, cast
 from datetime import date, datetime, timedelta
-from decimal import Decimal, InvalidOperation
+from decimal import Decimal
 from collections import defaultdict
 
 logger = logging.getLogger(__name__)
@@ -21,6 +21,8 @@ from opensteuerauszug.importers.common import (
     CashPositionData,
     SecurityNameMetadata,
     SecurityPositionData,
+    aggregate_mutations,
+    to_decimal,
 )
 from opensteuerauszug.render.translations import get_text, Language, DEFAULT_LANGUAGE
 
@@ -115,18 +117,7 @@ class IbkrImporter:
     def _to_decimal(self, value: object | None, field_name: str,
                     object_description: str) -> Decimal:
         """Converts a value to Decimal, raising ValueError on failure."""
-        if value is None:  # Should be caught by _get_required_field if required
-            raise ValueError(
-                f"Cannot convert None to Decimal for field '{field_name}' "
-                f"in {object_description}"
-            )
-        try:
-            return Decimal(str(value))
-        except InvalidOperation:
-            raise ValueError(
-                f"Invalid value for Decimal conversion: '{value}' for field "
-                f"'{field_name}' in {object_description}"
-            )
+        return to_decimal(value, field_name, object_description)
 
     def _normalize_country_code(self, value: object | None) -> str | None:
         if value is None:
@@ -191,49 +182,7 @@ class IbkrImporter:
 
     def _aggregate_stocks(self, stocks: List[SecurityStock]) -> List[SecurityStock]:
         """Aggregate buy and sell entries on the same date with equal order id if present without reordering."""
-
-        aggregated: List[SecurityStock] = []
-        pending: SecurityStock | None = None
-
-        for stock in stocks:
-            if stock.mutation:
-                if (
-                    pending
-                    and pending.referenceDate == stock.referenceDate
-                    and pending.orderId == stock.orderId
-                    and pending.balanceCurrency == stock.balanceCurrency
-                    and pending.quotationType == stock.quotationType
-                    # test for same sign of quantity
-                    and (pending.quantity * stock.quantity) > 0
-                ):
-                    total_quantity = pending.quantity + stock.quantity
-                    if pending.unitPrice != stock.unitPrice:
-                        pending.unitPrice = (pending.quantity * pending.unitPrice + stock.quantity * stock.unitPrice) / total_quantity
-
-                    pending.quantity = total_quantity
-                else:
-                    if pending:
-                        aggregated.append(pending)
-                    pending = SecurityStock(
-                        referenceDate=stock.referenceDate,
-                        mutation=True,
-                        quantity=stock.quantity,
-                        unitPrice=stock.unitPrice,
-                        name=stock.name,
-                        orderId=stock.orderId,
-                        balanceCurrency=stock.balanceCurrency,
-                        quotationType=stock.quotationType,
-                    )
-            else:
-                if pending:
-                    aggregated.append(pending)
-                    pending = None
-                aggregated.append(stock)
-
-        if pending:
-            aggregated.append(pending)
-
-        return aggregated
+        return aggregate_mutations(stocks)
 
     def _parse_flex_statements(
         self,

--- a/src/opensteuerauszug/importers/ibkr/ibkr_importer.py
+++ b/src/opensteuerauszug/importers/ibkr/ibkr_importer.py
@@ -19,7 +19,7 @@ from opensteuerauszug.config.models import IbkrAccountSettings
 from opensteuerauszug.core.constants import UNINITIALIZED_QUANTITY
 from opensteuerauszug.importers.common import (
     CashPositionData,
-    SecurityNameMetadata,
+    SecurityNameRegistry,
     SecurityPositionData,
     aggregate_mutations,
     to_decimal,
@@ -451,9 +451,8 @@ class IbkrImporter:
         processed_security_positions: defaultdict[SecurityPosition, SecurityPositionData] = \
             defaultdict(lambda: {'stocks': [], 'payments': []})
 
-        # Metadata for security names: {SecurityPosition: {'best_name': str, 'priority': int}}
-        security_name_metadata: defaultdict[SecurityPosition, SecurityNameMetadata] = \
-            defaultdict(lambda: {'best_name': None, 'priority': -1})
+        # Best-name-wins registry for security display names.
+        security_name_registry = SecurityNameRegistry()
 
         processed_cash_positions: defaultdict[tuple, CashPositionData] = \
             defaultdict(lambda: {'stocks': [], 'payments': []})
@@ -462,16 +461,6 @@ class IbkrImporter:
         # Map to store assetCategory and subCategory for each security
         security_asset_category_map: Dict[SecurityPosition, tuple[str, Optional[str]]] = {}
         rights_issue_positions: set[SecurityPosition] = set()
-
-        def _update_security_name_metadata(
-            sec_pos: SecurityPosition,
-            name: str,
-            priority: int,
-        ) -> None:
-            entry = security_name_metadata[sec_pos]
-            if priority > entry['priority']:
-                entry['best_name'] = name
-                entry['priority'] = priority
 
         for stmt in all_flex_statements:
             account_id = self._get_required_field(
@@ -570,7 +559,7 @@ class IbkrImporter:
                     )
 
                     # Update name metadata (Priority: 8 for Trades)
-                    _update_security_name_metadata(sec_pos, f"{description} ({symbol})", 8)
+                    security_name_registry.update(sec_pos, f"{description} ({symbol})", 8)
 
                     # Store assetCategory and subCategory
                     sub_category = getattr(trade, 'subCategory', None)
@@ -677,7 +666,7 @@ class IbkrImporter:
                     )
 
                     # Update name metadata (Priority: 10 for OpenPositions)
-                    _update_security_name_metadata(sec_pos, f"{description} ({symbol})", 10)
+                    security_name_registry.update(sec_pos, f"{description} ({symbol})", 10)
 
                     # Store assetCategory and subCategory
                     sub_category = getattr(open_pos, 'subCategory', None)
@@ -784,7 +773,7 @@ class IbkrImporter:
                     )
 
                     # Update name metadata (Priority: 5 for Transfers)
-                    _update_security_name_metadata(sec_pos, f"{description} ({symbol})", 5)
+                    security_name_registry.update(sec_pos, f"{description} ({symbol})", 5)
 
                     stock_mutation = SecurityStock(
                         referenceDate=tx_date,
@@ -863,7 +852,7 @@ class IbkrImporter:
                         ca_name = f"{description} ({symbol})"
                         ca_priority = 3
 
-                    _update_security_name_metadata(sec_pos, ca_name, ca_priority)
+                    security_name_registry.update(sec_pos, ca_name, ca_priority)
 
                     sub_category = getattr(action, "subCategory", None)
                     if sub_category == "RIGHT":
@@ -943,7 +932,7 @@ class IbkrImporter:
                         # Use description or symbol if description is generic?
                         # Usually description in CashTx is like "Dividend ...". Not great for security name.
                         # But if it's the only source, it's better than nothing.
-                        _update_security_name_metadata(
+                        security_name_registry.update(
                             sec_pos_key,
                             f"{description} ({sym_attr})" if sym_attr else description,
                             0
@@ -1139,18 +1128,8 @@ class IbkrImporter:
                 sorted_stocks, key=lambda s: (s.referenceDate, s.mutation)
             )
 
-            # Determine best security name
-            name_metadata = security_name_metadata[sec_pos_obj]
-            best_name = name_metadata['best_name']
-
-            if best_name:
-                final_security_name = best_name
-            else:
-                # Fallback to description from position key or just symbol
-                if sec_pos_obj.description:
-                    final_security_name = sec_pos_obj.description
-                else:
-                    final_security_name = sec_pos_obj.symbol
+            # Determine best security name (registry falls back to description, then symbol)
+            final_security_name = security_name_registry.resolve(sec_pos_obj)
 
             sec = Security(
                 positionId=sec_pos_idx,

--- a/src/opensteuerauszug/importers/ibkr/ibkr_importer.py
+++ b/src/opensteuerauszug/importers/ibkr/ibkr_importer.py
@@ -16,13 +16,14 @@ from opensteuerauszug.model.ech0196 import (
 )
 from opensteuerauszug.core.position_reconciler import PositionReconciler
 from opensteuerauszug.config.models import IbkrAccountSettings
-from opensteuerauszug.core.constants import UNINITIALIZED_QUANTITY
 from opensteuerauszug.importers.common import (
     CashPositionData,
     SecurityNameRegistry,
     SecurityPositionData,
     aggregate_mutations,
+    apply_withholding_tax_fields,
     build_client,
+    build_security_payment,
     parse_swiss_canton,
     resolve_first_last_name,
     to_decimal,
@@ -277,13 +278,7 @@ class IbkrImporter:
     ) -> None:
         if tx_type != ibflex.CashAction.WHTAX:
             return
-        if amount < 0:
-            if currency == "CHF":
-                payment.withHoldingTaxClaim = abs(amount)
-            else:
-                payment.nonRecoverableTaxAmountOriginal = abs(amount)
-        elif amount > 0:
-            payment.nonRecoverableTaxAmountOriginal = -amount
+        apply_withholding_tax_fields(payment, amount, currency)
 
     def _build_security_payment(
         self,
@@ -294,28 +289,15 @@ class IbkrImporter:
         amount: Decimal,
         tx_type: ibflex.CashAction,
     ) -> SecurityPayment:
-        tx_type_str = tx_type.value
-
-        payment = SecurityPayment(
-            paymentDate=payment_date,
-            name=description,
-            amountCurrency=currency,
+        return build_security_payment(
+            payment_date=payment_date,
+            description=description,
+            currency=currency,
             amount=amount,
-            quotationType='PIECE',
-            quantity=UNINITIALIZED_QUANTITY,
-            broker_label_original=tx_type_str,
+            broker_label=tx_type.value,
+            is_withholding=tx_type == ibflex.CashAction.WHTAX,
+            is_securities_lending=tx_type == ibflex.CashAction.PAYMENTINLIEU,
         )
-
-        if tx_type == ibflex.CashAction.PAYMENTINLIEU:
-            payment.securitiesLending = True
-
-        self._apply_withholding_tax_fields(
-            payment,
-            amount,
-            currency,
-            tx_type,
-        )
-        return payment
 
     def _import_corrections_flex_files(
         self,

--- a/src/opensteuerauszug/importers/ibkr/ibkr_importer.py
+++ b/src/opensteuerauszug/importers/ibkr/ibkr_importer.py
@@ -1,6 +1,6 @@
 import os
 import logging
-from typing import Final, List, Any, Dict, Optional, Sequence, get_args, cast
+from typing import Final, List, Any, Dict, Optional, Sequence
 from datetime import date, datetime, timedelta
 from decimal import Decimal
 from collections import defaultdict
@@ -9,10 +9,10 @@ logger = logging.getLogger(__name__)
 
 from opensteuerauszug.model.position import SecurityPosition
 from opensteuerauszug.model.ech0196 import (
-    BankAccountName, ClientNumber, Institution, SecurityCategory, TaxStatement, ListOfSecurities, ListOfBankAccounts,
+    BankAccountName, Institution, SecurityCategory, TaxStatement, ListOfSecurities, ListOfBankAccounts,
     Security, SecurityStock, SecurityPayment,
     BankAccount, BankAccountPayment, BankAccountTaxValue,
-    QuotationType, DepotNumber, BankAccountNumber, Depot, ISINType, Client, CantonAbbreviation
+    QuotationType, DepotNumber, BankAccountNumber, Depot, ISINType, Client
 )
 from opensteuerauszug.core.position_reconciler import PositionReconciler
 from opensteuerauszug.config.models import IbkrAccountSettings
@@ -22,6 +22,9 @@ from opensteuerauszug.importers.common import (
     SecurityNameRegistry,
     SecurityPositionData,
     aggregate_mutations,
+    build_client,
+    parse_swiss_canton,
+    resolve_first_last_name,
     to_decimal,
 )
 from opensteuerauszug.render.translations import get_text, Language, DEFAULT_LANGUAGE
@@ -1313,74 +1316,28 @@ class IbkrImporter:
         )
 
         # --- Create Client object ---
-        # TOOD: Handle joint accounts
-        client_obj = None
+        # TODO: Handle joint accounts
+        client_obj: Optional[Client] = None
         if all_flex_statements:
             first_statement = all_flex_statements[0]
-            if hasattr(first_statement, 'AccountInformation') and first_statement.AccountInformation:
-                acc_info = first_statement.AccountInformation
-                account_id = getattr(acc_info, 'accountId', None)
-                name = getattr(acc_info, 'name', None)
-                first_name = getattr(acc_info, 'firstName', None)
-                last_name = getattr(acc_info, 'lastName', None)
-                account_holder_name = getattr(acc_info, 'accountHolderName', None)
-                state_residential_address = getattr(acc_info, 'stateResidentialAddress', None)
-                # address1 = getattr(acc_info, 'address1', None)
-                # address2 = getattr(acc_info, 'address2', None)
-                # city = getattr(acc_info, 'city', None)
-                # state = getattr(acc_info, 'state', None)
-                # country = getattr(acc_info, 'country', None)
-                # postalCode = getattr(acc_info, 'postalCode', None)
-                
-                # Extract canton from stateResidentialAddress (format: "CH-ZH")
-                if state_residential_address and isinstance(state_residential_address, str):
-                    state_addr = state_residential_address.strip()
-                    if '-' in state_addr:
-                        parts = state_addr.split('-')
-                        if len(parts) == 2 and parts[0].upper() == 'CH':
-                            canton = parts[1].strip().upper()
-                            valid_cantons = get_args(CantonAbbreviation)
-                            if canton in valid_cantons:
-                                tax_statement.canton = cast(CantonAbbreviation, canton)
-                                logger.info(f"Set canton from IBKR stateResidentialAddress: {canton}")
-                            else:
-                                logger.warning(f"Invalid canton extracted from stateResidentialAddress: '{canton}'. Valid cantons are: {', '.join(valid_cantons)}")
-                        else:
-                            logger.debug(f"stateResidentialAddress '{state_addr}' does not match expected format 'CH-XX'")
-                    else:
-                        logger.debug(f"stateResidentialAddress '{state_addr}' does not contain a dash separator")
+            acc_info = getattr(first_statement, 'AccountInformation', None)
+            if acc_info:
+                canton = parse_swiss_canton(getattr(acc_info, 'stateResidentialAddress', None))
+                if canton:
+                    tax_statement.canton = canton
+                    logger.info(f"Set canton from IBKR stateResidentialAddress: {canton}")
 
-                client_first_name = None
-                client_last_name = None
-
-                # Helper function to check if a string value is valid (not None, not empty, not just whitespace)
-                def is_valid_string(value):
-                    return value is not None and isinstance(value, str) and value.strip()
-
-                def split_full_name(value):
-                    parts = str(value).strip().split()
-                    if len(parts) > 1:
-                        return parts[0], " ".join(parts[1:])
-                    return None, str(value).strip()
-
-                if is_valid_string(first_name) and is_valid_string(last_name):
-                    client_first_name = str(first_name).strip()
-                    client_last_name = str(last_name).strip()
-                elif is_valid_string(first_name) and is_valid_string(name):
-                    client_first_name = str(first_name).strip()
-                    _, client_last_name = split_full_name(name)
-                elif is_valid_string(name):
-                    client_first_name, client_last_name = split_full_name(name)
-                elif is_valid_string(account_holder_name):
-                    client_first_name, client_last_name = split_full_name(account_holder_name)
-
-                if account_id:
-                    client_obj = Client(
-                        clientNumber=ClientNumber(account_id),
-                        firstName=client_first_name,
-                        lastName=client_last_name,
-                        # Other fields like tin, salutation are not yet mapped
-                    )
+                client_first_name, client_last_name = resolve_first_last_name(
+                    first_name=getattr(acc_info, 'firstName', None),
+                    last_name=getattr(acc_info, 'lastName', None),
+                    full_name=getattr(acc_info, 'name', None),
+                    account_holder_name=getattr(acc_info, 'accountHolderName', None),
+                )
+                client_obj = build_client(
+                    client_number=getattr(acc_info, 'accountId', None),
+                    first_name=client_first_name,
+                    last_name=client_last_name,
+                )
         if client_obj:
             tax_statement.client = [client_obj]
         # --- End Client object ---

--- a/tests/importers/common/test_client.py
+++ b/tests/importers/common/test_client.py
@@ -1,0 +1,52 @@
+from opensteuerauszug.importers.common import (
+    build_client,
+    parse_swiss_canton,
+    resolve_first_last_name,
+    split_full_name,
+)
+
+
+def test_split_full_name_single_and_multi_token():
+    assert split_full_name("Madonna") == (None, "Madonna")
+    assert split_full_name("Firstname Lastname") == ("Firstname", "Lastname")
+    assert split_full_name("  First Middle Last  ") == ("First", "Middle Last")
+
+
+def test_resolve_prefers_explicit_first_last():
+    assert resolve_first_last_name(first_name="A", last_name="B") == ("A", "B")
+
+
+def test_resolve_combines_first_with_full_name_surname():
+    assert resolve_first_last_name(first_name="A", full_name="X Y Z") == ("A", "Y Z")
+
+
+def test_resolve_falls_back_to_account_holder_name():
+    assert resolve_first_last_name(account_holder_name="X Y") == ("X", "Y")
+
+
+def test_resolve_returns_none_when_nothing_valid():
+    assert resolve_first_last_name() == (None, None)
+    assert resolve_first_last_name(full_name="   ") == (None, None)
+
+
+def test_parse_canton_plain_code_and_address_form():
+    assert parse_swiss_canton("ZH") == "ZH"
+    assert parse_swiss_canton("zh") == "ZH"
+    assert parse_swiss_canton("CH-ZH") == "ZH"
+    assert parse_swiss_canton(" CH-be ") == "BE"
+
+
+def test_parse_canton_rejects_garbage_and_empty():
+    assert parse_swiss_canton(None) is None
+    assert parse_swiss_canton("") is None
+    assert parse_swiss_canton("XX") is None
+    assert parse_swiss_canton("US-CA") is None
+    assert parse_swiss_canton("CH-XX") is None
+
+
+def test_build_client_requires_client_number():
+    assert build_client(None, "A", "B") is None
+    assert build_client("", "A", "B") is None
+    c = build_client("U12345", "A", "B")
+    assert c is not None and c.clientNumber == "U12345"
+    assert c.firstName == "A" and c.lastName == "B"

--- a/tests/importers/common/test_parsing.py
+++ b/tests/importers/common/test_parsing.py
@@ -1,0 +1,21 @@
+from decimal import Decimal
+
+import pytest
+
+from opensteuerauszug.importers.common import to_decimal
+
+
+def test_to_decimal_accepts_string_and_numeric():
+    assert to_decimal("1.23", "x", "ctx") == Decimal("1.23")
+    assert to_decimal(2, "x", "ctx") == Decimal("2")
+    assert to_decimal(Decimal("3.5"), "x", "ctx") == Decimal("3.5")
+
+
+def test_to_decimal_rejects_none_with_context():
+    with pytest.raises(ValueError, match="field 'qty'.*Trade AAPL"):
+        to_decimal(None, "qty", "Trade AAPL")
+
+
+def test_to_decimal_rejects_garbage_with_context():
+    with pytest.raises(ValueError, match="Invalid value.*'abc'.*field 'qty'.*Trade AAPL"):
+        to_decimal("abc", "qty", "Trade AAPL")

--- a/tests/importers/common/test_payments.py
+++ b/tests/importers/common/test_payments.py
@@ -1,0 +1,70 @@
+from datetime import date
+from decimal import Decimal
+
+from opensteuerauszug.importers.common import (
+    apply_withholding_tax_fields,
+    build_security_payment,
+)
+from opensteuerauszug.core.constants import UNINITIALIZED_QUANTITY
+from opensteuerauszug.model.ech0196 import SecurityPayment
+
+
+def _blank_payment() -> SecurityPayment:
+    return SecurityPayment(
+        paymentDate=date(2024, 1, 1),
+        name="Div",
+        amountCurrency="USD",
+        amount=Decimal("10"),
+        quotationType="PIECE",
+        quantity=UNINITIALIZED_QUANTITY,
+    )
+
+
+def test_apply_withholding_negative_chf_sets_claim():
+    p = _blank_payment()
+    apply_withholding_tax_fields(p, Decimal("-5"), "CHF")
+    assert p.withHoldingTaxClaim == Decimal("5")
+    assert p.nonRecoverableTaxAmountOriginal is None
+
+
+def test_apply_withholding_negative_foreign_sets_non_recoverable():
+    p = _blank_payment()
+    apply_withholding_tax_fields(p, Decimal("-5"), "USD")
+    assert p.nonRecoverableTaxAmountOriginal == Decimal("5")
+    assert p.withHoldingTaxClaim is None
+
+
+def test_apply_withholding_positive_records_reversal():
+    p = _blank_payment()
+    apply_withholding_tax_fields(p, Decimal("5"), "USD")
+    assert p.nonRecoverableTaxAmountOriginal == Decimal("-5")
+
+
+def test_build_security_payment_basic():
+    p = build_security_payment(
+        payment_date=date(2024, 3, 1),
+        description="Dividend AAPL",
+        currency="USD",
+        amount=Decimal("42"),
+        broker_label="DIV",
+    )
+    assert p.paymentDate == date(2024, 3, 1)
+    assert p.name == "Dividend AAPL"
+    assert p.amount == Decimal("42")
+    assert p.broker_label_original == "DIV"
+    assert p.securitiesLending is None or p.securitiesLending is False
+    assert p.withHoldingTaxClaim is None
+
+
+def test_build_security_payment_securities_lending_and_withholding():
+    p = build_security_payment(
+        payment_date=date(2024, 3, 1),
+        description="wht",
+        currency="USD",
+        amount=Decimal("-3"),
+        broker_label="WHTAX",
+        is_securities_lending=True,
+        is_withholding=True,
+    )
+    assert p.securitiesLending is True
+    assert p.nonRecoverableTaxAmountOriginal == Decimal("3")

--- a/tests/importers/common/test_security_name.py
+++ b/tests/importers/common/test_security_name.py
@@ -1,0 +1,35 @@
+from opensteuerauszug.importers.common import SecurityNameRegistry
+from opensteuerauszug.model.position import SecurityPosition
+
+
+def _pos(symbol="AAPL", description=None):
+    return SecurityPosition(depot="D1", symbol=symbol, description=description)
+
+
+def test_higher_priority_wins():
+    registry = SecurityNameRegistry()
+    p = _pos()
+    registry.update(p, "low", priority=1)
+    registry.update(p, "high", priority=5)
+    registry.update(p, "mid", priority=3)
+    assert registry.best(p) == "high"
+
+
+def test_tie_keeps_existing():
+    registry = SecurityNameRegistry()
+    p = _pos()
+    registry.update(p, "first", priority=5)
+    registry.update(p, "second", priority=5)
+    assert registry.best(p) == "first"
+
+
+def test_resolve_falls_back_to_description_then_symbol():
+    registry = SecurityNameRegistry()
+    with_desc = _pos(symbol="AAPL", description="Apple Inc")
+    without_desc = _pos(symbol="MSFT")
+    # no name stored yet
+    assert registry.resolve(with_desc) == "Apple Inc"
+    assert registry.resolve(without_desc) == "MSFT"
+    # once a registered name is present, it wins
+    registry.update(with_desc, "Apple Inc (AAPL)", priority=10)
+    assert registry.resolve(with_desc) == "Apple Inc (AAPL)"

--- a/tests/importers/common/test_stock_aggregation.py
+++ b/tests/importers/common/test_stock_aggregation.py
@@ -1,0 +1,56 @@
+from datetime import date
+from decimal import Decimal
+
+from opensteuerauszug.importers.common import aggregate_mutations
+from opensteuerauszug.model.ech0196 import SecurityStock
+
+
+def _mut(qty, price, order_id="O1", d=date(2024, 6, 1)):
+    return SecurityStock(
+        referenceDate=d,
+        mutation=True,
+        quantity=Decimal(qty),
+        unitPrice=Decimal(price),
+        orderId=order_id,
+        balanceCurrency="USD",
+        quotationType="PIECE",
+    )
+
+
+def _balance(qty, d):
+    return SecurityStock(
+        referenceDate=d,
+        mutation=False,
+        quantity=Decimal(qty),
+        balanceCurrency="USD",
+        quotationType="PIECE",
+    )
+
+
+def test_same_order_same_side_merges_with_weighted_price():
+    result = aggregate_mutations([_mut("10", "100"), _mut("10", "110")])
+    assert len(result) == 1
+    assert result[0].quantity == Decimal("20")
+    assert result[0].unitPrice == Decimal("105")
+
+
+def test_different_order_id_does_not_merge():
+    result = aggregate_mutations(
+        [_mut("10", "100", order_id="O1"), _mut("10", "100", order_id="O2")]
+    )
+    assert len(result) == 2
+
+
+def test_opposite_side_does_not_merge():
+    result = aggregate_mutations([_mut("10", "100"), _mut("-5", "100")])
+    assert len(result) == 2
+
+
+def test_balance_entries_pass_through_and_break_pending():
+    result = aggregate_mutations(
+        [_mut("10", "100"), _balance("10", date(2024, 6, 2)), _mut("5", "100")]
+    )
+    # first mutation flushed on balance, second mutation kept separate
+    assert [s.mutation for s in result] == [True, False, True]
+    assert result[0].quantity == Decimal("10")
+    assert result[2].quantity == Decimal("5")


### PR DESCRIPTION
Groundwork refactor that pulls importer-agnostic glue out of `IbkrImporter` into a new `importers/common/` package, so #364 (Fidelity) and future importers can stop reaching into the IBKR module.

Composition-first: every piece below is a plain function or a small value object — no base class is introduced.

## Review-by-commit

Each commit stands on its own and keeps tests green; review one at a time.

1. **`importers/common/types.py` — accumulator TypedDicts.** `SecurityPositionData`, `CashPositionData`, `SecurityNameMetadata` move from `ibkr_importer` to a neutral home. IBKR keeps using them through the new import path.
2. **`to_decimal` + `aggregate_mutations`.** Two pure functions extracted from `IbkrImporter._to_decimal` / `_aggregate_stocks`. The IBKR methods become 1-line adapters so nothing external has to change. Unit tests added for both helpers.
3. **`SecurityNameRegistry`.** Small value object replacing the ad-hoc `defaultdict[SecurityPosition, {best_name, priority}]` + closure pattern. `resolve()` handles the "best name, else description, else symbol" fallback ladder. Unit tests added.
4. **Client + Swiss canton helpers.** `split_full_name`, `resolve_first_last_name`, `parse_swiss_canton`, `build_client`. IBKR's ~60 line nested closure + hand-rolled `CH-XX` parsing shrinks to a compact composition. Drops now-unused `get_args`, `cast`, `CantonAbbreviation`, `ClientNumber` imports. Unit tests added.
5. **`SecurityPayment` builder.** `apply_withholding_tax_fields` + `build_security_payment(..., is_withholding, is_securities_lending)`. Classification (ibflex enum vs Fidelity string) stays in the caller; only the construction is shared. Unit tests added.

## What is *not* in this PR

- The bank-accounts loop and the reconciliation/boundary-synthesis stage. Those are the biggest remaining duplication (IBKR vs Fidelity) but reshaping them touches ibflex-specific code paths; worth a dedicated PR.
- Any changes to Schwab code — it already has its own post-processing functions; moving those to `common/` deserves a follow-up.

## Test plan

- [x] `pytest tests/importers/` — 221 passed, 3 skipped (same count as baseline + 23 new unit tests for the common helpers).
- [x] No change to IBKR behaviour: existing IBKR integration tests pass.
- [ ] CI.

Follow-up PR will rebase #364 on top of this branch and rewrite the Fidelity importer to consume these helpers.
