### PR TITLE
Break out tax statement constrution and transaction post processing into sharable helpers.

### DIFF
--- a/src/opensteuerauszug/importers/common/__init__.py
+++ b/src/opensteuerauszug/importers/common/__init__.py
@@ -18,19 +18,31 @@ from .client import (
 )
 from .parsing import to_decimal
 from .payments import apply_withholding_tax_fields, build_security_payment
+from .postprocess import (
+    CashAccountEntry,
+    PositionHints,
+    augment_list_of_bank_accounts,
+    augment_list_of_securities,
+    fold_cash_payments,
+)
 from .security_name import SecurityNameRegistry
 from .stock_aggregation import aggregate_mutations
 from .types import CashPositionData, SecurityNameMetadata, SecurityPositionData
 
 __all__ = [
+    "CashAccountEntry",
     "CashPositionData",
+    "PositionHints",
     "SecurityPositionData",
     "SecurityNameMetadata",
     "SecurityNameRegistry",
     "aggregate_mutations",
     "apply_withholding_tax_fields",
+    "augment_list_of_bank_accounts",
+    "augment_list_of_securities",
     "build_client",
     "build_security_payment",
+    "fold_cash_payments",
     "is_nonempty_string",
     "parse_swiss_canton",
     "resolve_first_last_name",

--- a/src/opensteuerauszug/importers/common/postprocess.py
+++ b/src/opensteuerauszug/importers/common/postprocess.py
@@ -1,0 +1,444 @@
+"""Shared post-processing: fold per-position accumulators into a TaxStatement.
+
+After extraction each importer has two dict-of-accumulators:
+
+* ``processed_security_positions[SecurityPosition] -> SecurityPositionData``
+* ``processed_cash_positions[key] -> CashPositionData``
+
+and a ``SecurityNameRegistry`` capturing best-name-wins picks.  The loop
+that turns these into ``ListOfSecurities`` / ``ListOfBankAccounts`` is
+almost identical across importers — it aggregates same-day mutations,
+picks a currency/quotationType, reconciles period-start and period-end
+balances via :class:`PositionReconciler`, appends synthetic opening /
+closing boundary stocks when missing, sorts, and builds ``Security`` /
+``BankAccount`` models.
+
+The helpers in this module take a *partially filled* ``TaxStatement``
+— the importer pre-populates ``periodFrom`` / ``periodTo`` /
+``institution`` / ``client`` / ``canton`` — and augment it in place
+with ``listOfSecurities`` / ``listOfBankAccounts``.  Importer-specific
+flavour (which eCH category applies, whether short positions are
+allowed, whether to attach an ISIN) is routed through a callable or a
+small per-position :class:`PositionHints` record; no broker-specific
+types leak into this module.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import date, timedelta
+from decimal import Decimal
+from typing import (
+    Callable,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+)
+
+from opensteuerauszug.core.position_reconciler import PositionReconciler
+from opensteuerauszug.model.ech0196 import (
+    BankAccount,
+    BankAccountName,
+    BankAccountNumber,
+    BankAccountPayment,
+    BankAccountTaxValue,
+    Depot,
+    DepotNumber,
+    ISINType,
+    ListOfBankAccounts,
+    ListOfSecurities,
+    Security,
+    SecurityCategory,
+    SecurityStock,
+    TaxStatement,
+)
+from opensteuerauszug.model.position import SecurityPosition
+
+from .security_name import SecurityNameRegistry
+from .stock_aggregation import aggregate_mutations
+from .types import CashPositionData, SecurityPositionData
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class PositionHints:
+    """Per-position flavour that the shared postprocess needs from the caller.
+
+    Importers derive these from whatever broker-native classification
+    they keep (e.g. IBKR's ``asset_category``/``sub_category`` tuple or
+    Fidelity's bare category string).  Everything on this record has a
+    sensible default so callers only need to override what differs from
+    the common case.
+    """
+
+    security_category: SecurityCategory = "SHARE"
+    country: str = "US"
+    # Whether a negative tentative opening balance should be kept as-is
+    # (short positions / written options) rather than clamped to zero.
+    allow_negative_opening: bool = False
+    # Whether a final negative opening/closing balance should only warn
+    # instead of raising. Distinct from ``allow_negative_opening`` since
+    # IBKR distinguishes OPT/FOP vs OPT/FOP with sub C/P.
+    allow_negative_balance: bool = False
+    # Mark the synthesized Security as a rights issue.
+    is_rights_issue: bool = False
+    # Drop the security entirely when both opening and closing are zero.
+    skip_if_zero: bool = False
+
+
+_DEFAULT_HINTS = PositionHints()
+
+
+def _hints_for(
+    sec_pos: SecurityPosition,
+    hints_fn: Optional[Callable[[SecurityPosition], PositionHints]],
+) -> PositionHints:
+    if hints_fn is None:
+        return _DEFAULT_HINTS
+    return hints_fn(sec_pos)
+
+
+def _pick_currency_and_quotation(
+    stocks: Sequence[SecurityStock],
+    payments: Sequence,
+    identifier: str,
+) -> Tuple[str, str]:
+    """Replicates the IBKR/Fidelity currency + quotationType selection."""
+    primary_currency: Optional[str] = None
+    primary_quotation_type: str = "PIECE"
+    if stocks:
+        balance_stocks = [s for s in stocks if not s.mutation and s.balanceCurrency]
+        source = balance_stocks[0] if balance_stocks else stocks[0]
+        primary_currency = source.balanceCurrency
+        primary_quotation_type = source.quotationType
+    if not primary_currency:
+        if payments:
+            primary_currency = payments[0].amountCurrency
+        else:
+            raise ValueError(
+                f"Cannot determine currency for security {identifier}. "
+                "No stocks or payments with currency info."
+            )
+    return primary_currency, primary_quotation_type
+
+
+def _synthesize_boundary_balances(
+    stocks: List[SecurityStock],
+    *,
+    period_from: date,
+    period_to: date,
+    hints: PositionHints,
+    identifier: str,
+    strict_consistency: bool,
+    run_initial_consistency_check: bool,
+) -> Tuple[Decimal, Decimal, date]:
+    end_plus_one = period_to + timedelta(days=1)
+
+    if run_initial_consistency_check:
+        initial = PositionReconciler(
+            list(stocks), identifier=f"{identifier}-initial_check"
+        )
+        is_consistent, _ = initial.check_consistency(
+            print_log=True,
+            raise_on_error=strict_consistency,
+            assume_zero_if_no_balances=True,
+        )
+        if not is_consistent and not strict_consistency:
+            logger.warning(
+                "%s: initial consistency check on raw data failed; "
+                "proceeding with synthesis.",
+                identifier,
+            )
+
+    reconciler = PositionReconciler(
+        list(stocks), identifier=f"{identifier}-reconcile"
+    )
+    end_pos = reconciler.synthesize_position_at_date(end_plus_one)
+    closing_balance = end_pos.quantity if end_pos else Decimal("0")
+
+    start_pos = reconciler.synthesize_position_at_date(period_from)
+    if start_pos:
+        opening_balance = start_pos.quantity
+    else:
+        trades_quantity_total = sum(
+            (s.quantity for s in stocks if s.mutation), Decimal("0")
+        )
+        tentative = closing_balance - trades_quantity_total
+        opening_balance = (
+            tentative
+            if tentative >= 0 or hints.allow_negative_opening
+            else Decimal("0")
+        )
+
+    if opening_balance < 0 or closing_balance < 0:
+        message = (
+            f"Negative balance computed for security {identifier} "
+            f"(start {opening_balance}, end {closing_balance}). "
+            "In case you expect short positions, please report this to "
+            "the developers for further investigation."
+        )
+        if hints.allow_negative_balance:
+            logger.warning(message)
+        else:
+            raise ValueError(message)
+
+    return opening_balance, closing_balance, end_plus_one
+
+
+def _append_boundary_stock_if_missing(
+    stocks: List[SecurityStock],
+    *,
+    reference_date: date,
+    quantity: Decimal,
+    currency: str,
+    quotation_type: str,
+    name: Optional[str],
+    skip_when_zero: bool,
+) -> None:
+    exists = any(
+        (not s.mutation and s.referenceDate == reference_date) for s in stocks
+    )
+    if exists:
+        return
+    if skip_when_zero and quantity == 0:
+        return
+    stocks.append(
+        SecurityStock(
+            referenceDate=reference_date,
+            mutation=False,
+            quotationType=quotation_type,
+            quantity=quantity,
+            balanceCurrency=currency,
+            name=name,
+        )
+    )
+
+
+def augment_list_of_securities(
+    statement: TaxStatement,
+    positions: Mapping[SecurityPosition, SecurityPositionData],
+    *,
+    name_registry: SecurityNameRegistry,
+    hints_for: Optional[Callable[[SecurityPosition], PositionHints]] = None,
+    strict_consistency: bool = True,
+    run_initial_consistency_check: bool = False,
+    opening_stock_name: Optional[str] = None,
+    closing_stock_name: Optional[str] = None,
+) -> None:
+    """Fold ``positions`` into ``statement.listOfSecurities`` in place.
+
+    ``statement.periodFrom`` / ``statement.periodTo`` must be set; they
+    drive the boundary-balance synthesis.
+
+    ``hints_for`` lets the caller inject per-position category / country
+    / short-position flavour without leaking broker enums in here.
+    ``opening_stock_name`` / ``closing_stock_name`` are attached to the
+    synthetic balance rows when the caller wants a human-readable label
+    (Fidelity does; IBKR leaves them unnamed).
+    """
+    period_from = statement.periodFrom
+    period_to = statement.periodTo
+    if period_from is None or period_to is None:
+        raise ValueError(
+            "augment_list_of_securities requires statement.periodFrom and "
+            "statement.periodTo to be set before the call."
+        )
+
+    depot_securities_map: defaultdict[str, List[Security]] = defaultdict(list)
+    position_id = 0
+    for sec_pos_obj, data in positions.items():
+        position_id += 1
+        hints = _hints_for(sec_pos_obj, hints_for)
+
+        sorted_stocks = aggregate_mutations(data["stocks"])
+        sorted_payments = sorted(data["payments"], key=lambda p: p.paymentDate)
+
+        identifier = sec_pos_obj.symbol or sec_pos_obj.description or "<unknown>"
+        primary_currency, primary_quotation_type = _pick_currency_and_quotation(
+            sorted_stocks, sorted_payments, identifier
+        )
+
+        opening_balance, closing_balance, end_plus_one = _synthesize_boundary_balances(
+            sorted_stocks,
+            period_from=period_from,
+            period_to=period_to,
+            hints=hints,
+            identifier=identifier,
+            strict_consistency=strict_consistency,
+            run_initial_consistency_check=run_initial_consistency_check,
+        )
+
+        if hints.skip_if_zero and opening_balance == 0 and closing_balance == 0:
+            logger.info(
+                "Skipping security %s because balances are zero and "
+                "skip_if_zero is set.",
+                identifier,
+            )
+            continue
+
+        _append_boundary_stock_if_missing(
+            sorted_stocks,
+            reference_date=period_from,
+            quantity=opening_balance,
+            currency=primary_currency,
+            quotation_type=primary_quotation_type,
+            name=opening_stock_name,
+            skip_when_zero=True,
+        )
+        _append_boundary_stock_if_missing(
+            sorted_stocks,
+            reference_date=end_plus_one,
+            quantity=closing_balance,
+            currency=primary_currency,
+            quotation_type=primary_quotation_type,
+            name=closing_stock_name,
+            skip_when_zero=False,
+        )
+
+        sorted_stocks = sorted(
+            sorted_stocks, key=lambda s: (s.referenceDate, s.mutation)
+        )
+
+        security = Security(
+            positionId=position_id,
+            currency=primary_currency,
+            quotationType=primary_quotation_type,
+            securityCategory=hints.security_category,
+            securityName=name_registry.resolve(sec_pos_obj),
+            symbol=sec_pos_obj.symbol,
+            isin=(
+                ISINType(sec_pos_obj.isin)
+                if sec_pos_obj.isin is not None
+                else None
+            ),
+            valorNumber=sec_pos_obj.valor,
+            country=hints.country,
+            stock=sorted_stocks,
+            payment=sorted_payments,
+            is_rights_issue=hints.is_rights_issue,
+        )
+        depot_securities_map[sec_pos_obj.depot].append(security)
+
+    depots = [
+        Depot(depotNumber=DepotNumber(depot_id), security=securities)
+        for depot_id, securities in depot_securities_map.items()
+        if securities
+    ]
+    statement.listOfSecurities = (
+        ListOfSecurities(depot=depots) if depots else None
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bank-accounts side
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CashAccountEntry:
+    """Per-(account, currency) bucket consumed by :func:`augment_list_of_bank_accounts`.
+
+    Each importer produces these from its own source-of-truth: IBKR from
+    the ``CashReport`` section, Fidelity from the statement summary.
+    ``closing_balance`` is required (``None`` triggers a ValueError
+    during assembly, as in the original importer code).
+    """
+
+    account_id: str
+    currency: str
+    closing_balance: Optional[Decimal]
+    payments: List[BankAccountPayment] = field(default_factory=list)
+    country: str = "US"
+    name: Optional[str] = None
+    number: Optional[str] = None
+    opening_date: Optional[date] = None
+    closing_date: Optional[date] = None
+
+
+def fold_cash_payments(
+    seed_entries: Iterable[CashAccountEntry],
+    processed_cash_positions: Mapping[tuple, CashPositionData],
+) -> List[CashAccountEntry]:
+    """Merge ``processed_cash_positions`` payments onto ``seed_entries``.
+
+    Seeds are matched on ``(account_id, currency)``.  Payment-only
+    buckets (i.e. currencies with cash transactions but no closing
+    balance in the statement summary) produce a synthetic entry with
+    ``closing_balance=None`` — downstream ``augment_list_of_bank_accounts``
+    will surface this as a ValueError, preserving existing behaviour.
+    """
+    by_key: dict[tuple[str, str], CashAccountEntry] = {}
+    for entry in seed_entries:
+        by_key[(entry.account_id, entry.currency)] = entry
+
+    for (stmt_account_id, currency_code, _), data in processed_cash_positions.items():
+        key = (str(stmt_account_id), str(currency_code))
+        if key in by_key:
+            by_key[key].payments.extend(data["payments"])
+        else:
+            by_key[key] = CashAccountEntry(
+                account_id=str(stmt_account_id),
+                currency=str(currency_code),
+                closing_balance=None,
+                payments=list(data["payments"]),
+            )
+    return list(by_key.values())
+
+
+def augment_list_of_bank_accounts(
+    statement: TaxStatement,
+    entries: Iterable[CashAccountEntry],
+) -> None:
+    """Fold ``entries`` into ``statement.listOfBankAccounts`` in place.
+
+    ``statement.periodTo`` is used as the ``BankAccountTaxValue``
+    reference date.  Entries without a ``closing_balance`` raise, which
+    matches the existing IBKR / Fidelity behaviour ("hard error if no
+    closing balance").
+    """
+    period_to = statement.periodTo
+    if period_to is None:
+        raise ValueError(
+            "augment_list_of_bank_accounts requires statement.periodTo "
+            "to be set before the call."
+        )
+
+    bank_accounts: List[BankAccount] = []
+    for entry in entries:
+        if entry.closing_balance is None:
+            raise ValueError(
+                f"No closing cash balance for account {entry.account_id}, "
+                f"currency {entry.currency} for date {period_to}."
+            )
+        name = entry.name or f"{entry.account_id} {entry.currency}"
+        number = entry.number or f"{entry.account_id}-{entry.currency}"
+        sorted_payments = sorted(
+            entry.payments or [], key=lambda p: p.paymentDate
+        )
+        tax_value = BankAccountTaxValue(
+            referenceDate=period_to,
+            balanceCurrency=entry.currency,
+            balance=entry.closing_balance,
+        )
+        bank_accounts.append(
+            BankAccount(
+                bankAccountName=BankAccountName(name),
+                bankAccountNumber=BankAccountNumber(number),
+                bankAccountCountry=entry.country,
+                bankAccountCurrency=entry.currency,
+                openingDate=entry.opening_date,
+                closingDate=entry.closing_date,
+                payment=sorted_payments,
+                taxValue=tax_value,
+            )
+        )
+    statement.listOfBankAccounts = (
+        ListOfBankAccounts(bankAccount=bank_accounts) if bank_accounts else None
+    )

--- a/src/opensteuerauszug/importers/ibkr/ibkr_importer.py
+++ b/src/opensteuerauszug/importers/ibkr/ibkr_importer.py
@@ -9,21 +9,23 @@ logger = logging.getLogger(__name__)
 
 from opensteuerauszug.model.position import SecurityPosition
 from opensteuerauszug.model.ech0196 import (
-    BankAccountName, Institution, SecurityCategory, TaxStatement, ListOfSecurities, ListOfBankAccounts,
-    Security, SecurityStock, SecurityPayment,
-    BankAccount, BankAccountPayment, BankAccountTaxValue,
-    QuotationType, DepotNumber, BankAccountNumber, Depot, ISINType, Client
+    BankAccountPayment, Institution, ISINType, SecurityCategory,
+    SecurityPayment, SecurityStock, TaxStatement, Client,
 )
-from opensteuerauszug.core.position_reconciler import PositionReconciler
 from opensteuerauszug.config.models import IbkrAccountSettings
 from opensteuerauszug.importers.common import (
+    CashAccountEntry,
     CashPositionData,
+    PositionHints,
     SecurityNameRegistry,
     SecurityPositionData,
     aggregate_mutations,
     apply_withholding_tax_fields,
+    augment_list_of_bank_accounts,
+    augment_list_of_securities,
     build_client,
     build_security_payment,
+    fold_cash_payments,
     parse_swiss_canton,
     resolve_first_last_name,
     to_decimal,
@@ -986,170 +988,52 @@ class IbkrImporter:
                 processed_security_positions,
             )
 
-        # --- Construct ListOfSecurities ---
-        # account_id -> list of Security objects
-        depot_securities_map: defaultdict[str, List[Security]] = defaultdict(list)
-        sec_pos_idx = 0
-        for sec_pos_obj, data in processed_security_positions.items():
-            sec_pos_idx += 1
-            sorted_stocks = self._aggregate_stocks(data['stocks'])
-            sorted_payments = sorted(
-                data['payments'], key=lambda p: p.paymentDate
+        # --- Assemble the partial TaxStatement and augment it via the shared
+        # post-processing stage. The client/institution/canton block below
+        # continues to write onto the same object.
+        tax_statement = TaxStatement(
+            minorVersion=1,
+            periodFrom=self.period_from,
+            periodTo=self.period_to,
+            taxPeriod=self.period_from.year,
+        )
+
+        ignore_rights_issues_by_account: Dict[str, bool] = {
+            s.account_number: getattr(s, "ignore_rights_issues", False)
+            for s in self.account_settings_list
+            if getattr(s, "account_number", None)
+        }
+
+        def _hints_for(sec_pos: SecurityPosition) -> PositionHints:
+            asset_cat, sub_category = security_asset_category_map.get(
+                sec_pos, ("STK", None)
             )
-
-            # Determine currency and quotation type from stocks or defaults
-            primary_currency = None
-            primary_quotation_type: QuotationType = "PIECE" # Default
-            if sorted_stocks:
-                # Try balance entry first, then any entry
-                balance_stocks = [
-                    s for s in sorted_stocks if not s.mutation and s.balanceCurrency
-                ]
-                if balance_stocks:
-                    primary_currency = balance_stocks[0].balanceCurrency
-                    primary_quotation_type = balance_stocks[0].quotationType
-                else:  # Try any stock
-                    primary_currency = sorted_stocks[0].balanceCurrency
-                    primary_quotation_type = sorted_stocks[0].quotationType
-
-            if not primary_currency:  # Fallback if no stocks or no currency
-                if sorted_payments:
-                    primary_currency = sorted_payments[0].amountCurrency
-                else:
-                    raise ValueError(
-                        f"Cannot determine currency for security "
-                        f"{sec_pos_obj.symbol} (Desc: {sec_pos_obj.description}). "
-                        f"No stocks or payments with currency info."
-                    )
-
-            # TODO: Map assetCategory to eCH-0196 SecurityCategory
-            # Get assetCategory and subCategory from the map, default to "STK"
-            asset_cat = 'STK'
-            sub_category = None
-            if sec_pos_obj in security_asset_category_map:
-                asset_cat, sub_category = security_asset_category_map[sec_pos_obj]
-
             sec_category = IBKR_ASSET_CATEGORY_TO_ECH_SECURITY_CATEGORY.get(asset_cat)
             if not sec_category:
                 raise ValueError(f"Unknown asset category: {asset_cat}")
-
-            # --- Ensure balance at period start and period end + 1 using PositionReconciler ---
-            reconciler = PositionReconciler(list(sorted_stocks), identifier=f"{sec_pos_obj.symbol}-reconcile")
-            end_plus_one = self.period_to + timedelta(days=1)
-            end_pos = reconciler.synthesize_position_at_date(end_plus_one)
-            closing_balance = end_pos.quantity if end_pos else Decimal("0")
-
-            trades_quantity_total = sum(
-                s.quantity for s in sorted_stocks if s.mutation
+            is_option = asset_cat in ("OPT", "FOP")
+            is_short_option_like = is_option and sub_category in ("C", "P")
+            is_rights = sec_pos in rights_issue_positions
+            skip_if_zero = is_rights and ignore_rights_issues_by_account.get(
+                sec_pos.depot, False
+            )
+            return PositionHints(
+                security_category=sec_category,
+                country=security_country_map.get(sec_pos, "US"),
+                allow_negative_opening=is_option,
+                allow_negative_balance=is_short_option_like,
+                is_rights_issue=is_rights,
+                skip_if_zero=skip_if_zero,
             )
 
-            start_pos = reconciler.synthesize_position_at_date(self.period_from)
-            if start_pos:
-                opening_balance = start_pos.quantity
-            else:
-                tentative_opening = closing_balance - trades_quantity_total
-                opening_balance = tentative_opening if tentative_opening >= 0 or asset_cat in ["OPT", "FOP"] else Decimal("0")
+        augment_list_of_securities(
+            tax_statement,
+            processed_security_positions,
+            name_registry=security_name_registry,
+            hints_for=_hints_for,
+        )
 
-            if opening_balance < 0 or closing_balance < 0:
-                if (asset_cat == "OPT" or asset_cat == "FOP") and (sub_category == "C" or sub_category == "P"):
-                    logger.warning(
-                        f"Negative balance computed for security {sec_pos_obj.symbol} with {asset_cat}/{sub_category}. In case you expect short positions, this is fine. Otherwise, please report this to the developers for further investigation."
-                        f" (start {opening_balance}, end {closing_balance})"
-                    )
-                else:
-                    raise ValueError(
-                        f"Negative balance computed for security {sec_pos_obj.symbol} with {asset_cat}/{sub_category}. In case you expect short positions, please report this to the developers for further investigation."
-                        f" (start {opening_balance}, end {closing_balance})"
-                    )
-
-            # Check if this is a rights issue and if we should skip it
-            is_rights_issue = sec_pos_obj in rights_issue_positions
-
-            # Find settings for this account
-            account_settings = next(
-                (s for s in self.account_settings_list if s.account_number == sec_pos_obj.depot),
-                None
-            )
-            ignore_rights_issues = getattr(account_settings, "ignore_rights_issues", False) if account_settings else False
-
-            if is_rights_issue and ignore_rights_issues and opening_balance == 0 and closing_balance == 0:
-                logger.info(
-                    "Skipping rights issue %s because balances are zero and ignore_rights_issues is set.",
-                    sec_pos_obj.symbol
-                )
-                continue
-
-            start_exists = any(
-                (not s.mutation and s.referenceDate == self.period_from)
-                for s in sorted_stocks
-            )
-            if not start_exists and opening_balance != 0:
-                sorted_stocks.append(
-                    SecurityStock(
-                        referenceDate=self.period_from,
-                        mutation=False,
-                        quotationType=primary_quotation_type,
-                        quantity=opening_balance,
-                        balanceCurrency=primary_currency
-                    )
-                )
-
-            end_exists = any(
-                (not s.mutation and s.referenceDate == end_plus_one)
-                for s in sorted_stocks
-            )
-            if not end_exists:
-                sorted_stocks.append(
-                    SecurityStock(
-                        referenceDate=end_plus_one,
-                        mutation=False,
-                        quotationType=primary_quotation_type,
-                        quantity=closing_balance,
-                        balanceCurrency=primary_currency
-                    )
-                )
-
-            sorted_stocks = sorted(
-                sorted_stocks, key=lambda s: (s.referenceDate, s.mutation)
-            )
-
-            # Determine best security name (registry falls back to description, then symbol)
-            final_security_name = security_name_registry.resolve(sec_pos_obj)
-
-            sec = Security(
-                positionId=sec_pos_idx,
-                currency=primary_currency,
-                quotationType=primary_quotation_type,
-                securityCategory=sec_category,
-                securityName=final_security_name,
-                isin=ISINType(sec_pos_obj.isin) if sec_pos_obj.isin is not None else None,
-                valorNumber=sec_pos_obj.valor,
-                country=security_country_map.get(sec_pos_obj, "US"),
-                stock=sorted_stocks,
-                payment=sorted_payments
-            )
-
-            if is_rights_issue:
-                sec.is_rights_issue = True
-
-            depot_securities_map[sec_pos_obj.depot].append(sec)
-
-        final_depots = []
-        if depot_securities_map:
-            for depot_id, securities_in_depot in depot_securities_map.items():
-                if securities_in_depot:
-                    final_depots.append(
-                        Depot(depotNumber=DepotNumber(depot_id),
-                              security=securities_in_depot)
-                    )
-
-        list_of_securities = (ListOfSecurities(depot=final_depots)
-                              if final_depots else None)
-
-        # --- Extract account opening/closing dates from AccountInformation ---
-        # Build a per-account map so dates are only applied to bank accounts
-        # originating from the same flex statement.
-        # The cleanup calculator will later clear them if they fall outside the reporting window.
+        # --- Collect per-account dateOpened / dateClosed + CashReport seeds ---
         account_dates: Dict[str, Dict[str, date | None]] = {}
         for s_stmt in all_flex_statements:
             stmt_account_id = self._get_required_field(
@@ -1162,129 +1046,55 @@ class IbkrImporter:
                     'dateClosed': acc_info.dateClosed,
                 }
 
-        # --- Construct ListOfBankAccounts ---
-        final_bank_accounts: List[BankAccount] = []
-        
-        # First, collect all currencies from CashReport that have closing balances
-        all_currencies_with_balances: Dict[tuple, Dict[str, Any]] = {}
-        
+        seed_entries: List[CashAccountEntry] = []
         for s_stmt in all_flex_statements:
             account_id = s_stmt.accountId
-            if s_stmt.CashReport:
-                for cash_report_currency_obj in s_stmt.CashReport:
-                    entry_account_id = getattr(cash_report_currency_obj, "accountId", None)
-                    if should_skip_pseudo_account_entry(cash_report_currency_obj):
-                        logger.info(
-                            "Skipping CashReport entry with pseudo accountId in account %s",
-                            account_id,
-                        )
-                        continue
-                    curr = cash_report_currency_obj.currency
+            if not s_stmt.CashReport:
+                continue
+            for cash_report_currency_obj in s_stmt.CashReport:
+                if should_skip_pseudo_account_entry(cash_report_currency_obj):
+                    logger.info(
+                        "Skipping CashReport entry with pseudo accountId in account %s",
+                        account_id,
+                    )
+                    continue
+                curr = cash_report_currency_obj.currency
+                if curr == "BASE_SUMMARY":
+                    continue
 
-                    # Skip BASE_SUMMARY entries (IBKR internal aggregation, not a real currency)
-                    if curr == "BASE_SUMMARY":
-                        continue
+                closing_balance_value: Optional[Decimal] = None
+                if cash_report_currency_obj.endingCash is not None:
+                    closing_balance_value = self._to_decimal(
+                        cash_report_currency_obj.endingCash,
+                        'endingCash',
+                        f"CashReport {account_id} {curr}",
+                    )
+                elif (
+                    cash_report_currency_obj.balance is not None
+                    and cash_report_currency_obj.reportDate == self.period_to
+                ):
+                    closing_balance_value = self._to_decimal(
+                        cash_report_currency_obj.balance,
+                        'balance',
+                        f"CashReport {account_id} {curr}",
+                    )
 
-                    key = (account_id, curr)
-
-                    # Extract closing balance
-                    closing_balance_value = None
-                    if cash_report_currency_obj.endingCash is not None:
-                        closing_balance_value = self._to_decimal(
-                            cash_report_currency_obj.endingCash,
-                            'endingCash',
-                            f"CashReport {account_id} {curr}"
-                        )
-                    elif (
-                        cash_report_currency_obj.balance is not None
-                        and cash_report_currency_obj.reportDate == self.period_to
-                    ):
-                        closing_balance_value = self._to_decimal(
-                            cash_report_currency_obj.balance,
-                            'balance',
-                            f"CashReport {account_id} {curr}"
-                        )
-
-                    if closing_balance_value is not None:
-                        all_currencies_with_balances[key] = {
-                            'account_id': account_id,
-                            'currency': curr,
-                            'closing_balance': closing_balance_value,
-                            'payments': []
-                        }
-
-        # Now add payments from cash transactions to the relevant currencies
-        for (stmt_account_id, currency_code, _), data in processed_cash_positions.items():
-            key = (stmt_account_id, currency_code)
-            if key in all_currencies_with_balances:
-                all_currencies_with_balances[key]['payments'].extend(data['payments'])
-            else:
-                # This currency has transactions but no closing balance in CashReport
-                # Still create an entry for it
-                all_currencies_with_balances[key] = {
-                    'account_id': stmt_account_id,
-                    'currency': currency_code,
-                    'closing_balance': None,
-                    'payments': data['payments']
-                }
-
-        # Create bank accounts for all currencies
-        for key, data_dict in all_currencies_with_balances.items():
-            acc_id = data_dict['account_id']
-            curr = data_dict['currency']
-            payments = data_dict['payments']
-            closing_balance_value = data_dict['closing_balance']
-
-            # Ensure payments is a list before sorting
-            sorted_payments = sorted(payments or [], key=lambda p: p.paymentDate)
-
-            bank_account_tax_value_obj = None
-            if closing_balance_value is not None:
-                bank_account_tax_value_obj = BankAccountTaxValue(
-                    referenceDate=self.period_to,
-                    balanceCurrency=curr,
-                    balance=closing_balance_value
-                )
-            else:
-                logger.warning(
-                    f"No closing cash balance found in CashReport "
-                    f"for account {acc_id}, currency {curr} for date "
-                    f"{self.period_to}."
-                )
-                raise ValueError(
-                    f"No closing cash balance found in CashReport "
-                    f"for account {acc_id}, currency {curr} for date "
-                    f"{self.period_to}."
+                if closing_balance_value is None:
+                    continue
+                dates_for_account = account_dates.get(account_id, {})
+                seed_entries.append(
+                    CashAccountEntry(
+                        account_id=account_id,
+                        currency=curr,
+                        closing_balance=closing_balance_value,
+                        opening_date=dates_for_account.get('dateOpened'),
+                        closing_date=dates_for_account.get('dateClosed'),
+                    )
                 )
 
-            bank_account_num_str = f"{acc_id}-{curr}"
-            bank_account_name_str = f"{acc_id} {curr}"
+        cash_entries = fold_cash_payments(seed_entries, processed_cash_positions)
+        augment_list_of_bank_accounts(tax_statement, cash_entries)
 
-            # Look up dates for this specific account
-            dates_for_account = account_dates.get(acc_id, {})
-            ba = BankAccount(
-                bankAccountName=BankAccountName(bank_account_name_str),
-                bankAccountNumber=BankAccountNumber(bank_account_num_str),
-                bankAccountCountry="US",
-                bankAccountCurrency=curr,
-                openingDate=dates_for_account.get('dateOpened'),
-                closingDate=dates_for_account.get('dateClosed'),
-                payment=sorted_payments,
-                taxValue=bank_account_tax_value_obj # Adjusted to single obj
-            )
-            final_bank_accounts.append(ba)
-
-        list_of_bank_accounts = (ListOfBankAccounts(bankAccount=final_bank_accounts)
-                                 if final_bank_accounts else None)
-
-        tax_statement = TaxStatement(
-            minorVersion=1,
-            periodFrom=self.period_from,
-            periodTo=self.period_to,
-            taxPeriod=self.period_from.year,
-            listOfSecurities=list_of_securities,
-            listOfBankAccounts=list_of_bank_accounts
-        )
         logger.info(
             "Partial TaxStatement created with Trades, OpenPositions, "
             "and basic CashTransactions mapping."

--- a/tests/importers/common/test_postprocess.py
+++ b/tests/importers/common/test_postprocess.py
@@ -1,0 +1,241 @@
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from opensteuerauszug.importers.common import (
+    CashAccountEntry,
+    PositionHints,
+    SecurityNameRegistry,
+    SecurityPositionData,
+    augment_list_of_bank_accounts,
+    augment_list_of_securities,
+    fold_cash_payments,
+)
+from opensteuerauszug.model.ech0196 import (
+    BankAccountPayment,
+    SecurityStock,
+    TaxStatement,
+)
+from opensteuerauszug.model.position import SecurityPosition
+
+
+def _partial_statement() -> TaxStatement:
+    return TaxStatement(
+        minorVersion=1,
+        periodFrom=date(2024, 1, 1),
+        periodTo=date(2024, 12, 31),
+        taxPeriod=2024,
+    )
+
+
+def _buy(symbol: str, *, on: date, qty: Decimal, price: Decimal) -> SecurityStock:
+    return SecurityStock(
+        referenceDate=on,
+        mutation=True,
+        quantity=qty,
+        unitPrice=price,
+        balanceCurrency="USD",
+        quotationType="PIECE",
+        name="buy",
+    )
+
+
+def test_augment_securities_synthesizes_opening_and_closing_balances():
+    statement = _partial_statement()
+    sec_pos = SecurityPosition(depot="D1", symbol="AAPL", description="Apple (AAPL)")
+    trade = _buy("AAPL", on=date(2024, 3, 1), qty=Decimal("10"), price=Decimal("100"))
+    # Closing balance snapshot provided by the caller at period_end + 1
+    closing = SecurityStock(
+        referenceDate=date(2025, 1, 1),
+        mutation=False,
+        quantity=Decimal("10"),
+        balanceCurrency="USD",
+        quotationType="PIECE",
+        unitPrice=Decimal("100"),
+    )
+
+    positions = {sec_pos: SecurityPositionData(stocks=[trade, closing], payments=[])}
+    registry = SecurityNameRegistry()
+    registry.update(sec_pos, "Apple Inc. (AAPL)", 10)
+
+    augment_list_of_securities(
+        statement,
+        positions,
+        name_registry=registry,
+        hints_for=lambda _: PositionHints(security_category="SHARE", country="US"),
+    )
+
+    assert statement.listOfSecurities is not None
+    depot = statement.listOfSecurities.depot[0]
+    assert depot.depotNumber == "D1"
+    (security,) = depot.security
+    assert security.securityName == "Apple Inc. (AAPL)"
+    assert security.country == "US"
+    assert security.securityCategory == "SHARE"
+    # Synthesized opening balance at 2024-01-01 (qty 0 before the buy)
+    # -> since opening qty is 0 we don't append; we only append closing.
+    # Assert the closing boundary stock at 2025-01-01 is present.
+    balance_dates = sorted(
+        (s.referenceDate, s.mutation, s.quantity) for s in security.stock
+    )
+    assert (date(2025, 1, 1), False, Decimal("10")) in balance_dates
+
+
+def test_augment_securities_raises_on_negative_balance_by_default():
+    statement = _partial_statement()
+    sec_pos = SecurityPosition(depot="D1", symbol="XYZ", description="XYZ")
+    sell = SecurityStock(
+        referenceDate=date(2024, 6, 1),
+        mutation=True,
+        quantity=Decimal("-5"),
+        unitPrice=Decimal("10"),
+        balanceCurrency="USD",
+        quotationType="PIECE",
+    )
+    zero_close = SecurityStock(
+        referenceDate=date(2025, 1, 1),
+        mutation=False,
+        quantity=Decimal("-5"),
+        balanceCurrency="USD",
+        quotationType="PIECE",
+        unitPrice=Decimal("10"),
+    )
+    positions = {sec_pos: SecurityPositionData(stocks=[sell, zero_close], payments=[])}
+
+    with pytest.raises(ValueError, match="Negative balance"):
+        augment_list_of_securities(
+            statement,
+            positions,
+            name_registry=SecurityNameRegistry(),
+            hints_for=lambda _: PositionHints(),
+        )
+
+
+def test_augment_securities_allow_negative_balance_warns(caplog):
+    statement = _partial_statement()
+    sec_pos = SecurityPosition(depot="D1", symbol="OPT1", description="OPT1")
+    sell = SecurityStock(
+        referenceDate=date(2024, 6, 1),
+        mutation=True,
+        quantity=Decimal("-1"),
+        unitPrice=Decimal("1"),
+        balanceCurrency="USD",
+        quotationType="PIECE",
+    )
+    close = SecurityStock(
+        referenceDate=date(2025, 1, 1),
+        mutation=False,
+        quantity=Decimal("-1"),
+        balanceCurrency="USD",
+        quotationType="PIECE",
+        unitPrice=Decimal("1"),
+    )
+    positions = {sec_pos: SecurityPositionData(stocks=[sell, close], payments=[])}
+
+    with caplog.at_level("WARNING"):
+        augment_list_of_securities(
+            statement,
+            positions,
+            name_registry=SecurityNameRegistry(),
+            hints_for=lambda _: PositionHints(
+                allow_negative_opening=True, allow_negative_balance=True
+            ),
+        )
+
+    assert "Negative balance" in caplog.text
+    assert statement.listOfSecurities is not None
+
+
+def test_augment_securities_skip_if_zero():
+    statement = _partial_statement()
+    sec_pos = SecurityPosition(depot="D1", symbol="ZERO", description="ZERO")
+    stock = SecurityStock(
+        referenceDate=date(2025, 1, 1),
+        mutation=False,
+        quantity=Decimal("0"),
+        balanceCurrency="USD",
+        quotationType="PIECE",
+        unitPrice=Decimal("1"),
+    )
+    positions = {sec_pos: SecurityPositionData(stocks=[stock], payments=[])}
+
+    augment_list_of_securities(
+        statement,
+        positions,
+        name_registry=SecurityNameRegistry(),
+        hints_for=lambda _: PositionHints(skip_if_zero=True),
+    )
+    assert statement.listOfSecurities is None
+
+
+def test_fold_cash_payments_joins_on_account_and_currency():
+    seed = [
+        CashAccountEntry(
+            account_id="A1",
+            currency="USD",
+            closing_balance=Decimal("100"),
+        )
+    ]
+    pay = BankAccountPayment(
+        paymentDate=date(2024, 2, 1),
+        name="interest",
+        amountCurrency="USD",
+        amount=Decimal("1"),
+    )
+    processed = {("A1", "USD", "MAIN"): {"stocks": [], "payments": [pay]}}
+
+    merged = fold_cash_payments(seed, processed)
+    (entry,) = merged
+    assert entry.closing_balance == Decimal("100")
+    assert entry.payments == [pay]
+
+
+def test_fold_cash_payments_creates_orphan_entries_without_balance():
+    pay = BankAccountPayment(
+        paymentDate=date(2024, 2, 1),
+        name="interest",
+        amountCurrency="EUR",
+        amount=Decimal("1"),
+    )
+    processed = {("A1", "EUR", "MAIN"): {"stocks": [], "payments": [pay]}}
+
+    merged = fold_cash_payments([], processed)
+    (entry,) = merged
+    assert entry.currency == "EUR"
+    assert entry.closing_balance is None
+    assert entry.payments == [pay]
+
+
+def test_augment_bank_accounts_requires_closing_balance():
+    statement = _partial_statement()
+    entry = CashAccountEntry(
+        account_id="A1", currency="USD", closing_balance=None, payments=[]
+    )
+    with pytest.raises(ValueError, match="No closing cash balance"):
+        augment_list_of_bank_accounts(statement, [entry])
+
+
+def test_augment_bank_accounts_builds_list():
+    statement = _partial_statement()
+    pay = BankAccountPayment(
+        paymentDate=date(2024, 2, 1),
+        name="interest",
+        amountCurrency="USD",
+        amount=Decimal("1"),
+    )
+    entry = CashAccountEntry(
+        account_id="A1",
+        currency="USD",
+        closing_balance=Decimal("100"),
+        payments=[pay],
+    )
+    augment_list_of_bank_accounts(statement, [entry])
+
+    assert statement.listOfBankAccounts is not None
+    (ba,) = statement.listOfBankAccounts.bankAccount
+    assert ba.bankAccountName == "A1 USD"
+    assert ba.bankAccountNumber == "A1-USD"
+    assert ba.bankAccountCurrency == "USD"
+    assert ba.taxValue.balance == Decimal("100")
+    assert ba.payment == [pay]


### PR DESCRIPTION
Claude generated change to move common post process and tax statement building into shared helper code.

TODO: think about pipelining this instead of having the imports tail cal into the helpers.

Eventually schwab can use this too, but needs a tad more work