### PR TITLE
fix: allow negative balances to pass through importer for all asset types

### DIFF
--- a/src/opensteuerauszug/importers/ibkr/ibkr_importer.py
+++ b/src/opensteuerauszug/importers/ibkr/ibkr_importer.py
@@ -1048,19 +1048,14 @@ class IbkrImporter:
                 opening_balance = start_pos.quantity
             else:
                 tentative_opening = closing_balance - trades_quantity_total
-                opening_balance = tentative_opening if tentative_opening >= 0 or asset_cat in ["OPT", "FOP"] else Decimal("0")
+                opening_balance = tentative_opening
 
             if opening_balance < 0 or closing_balance < 0:
-                if (asset_cat == "OPT" or asset_cat == "FOP") and (sub_category == "C" or sub_category == "P"):
-                    logger.warning(
-                        f"Negative balance computed for security {sec_pos_obj.symbol} with {asset_cat}/{sub_category}. In case you expect short positions, this is fine. Otherwise, please report this to the developers for further investigation."
-                        f" (start {opening_balance}, end {closing_balance})"
-                    )
-                else:
-                    raise ValueError(
-                        f"Negative balance computed for security {sec_pos_obj.symbol} with {asset_cat}/{sub_category}. In case you expect short positions, please report this to the developers for further investigation."
-                        f" (start {opening_balance}, end {closing_balance})"
-                    )
+                logger.debug(
+                    f"Negative balance for {sec_pos_obj.symbol} ({asset_cat}/{sub_category}): "
+                    f"start={opening_balance}, end={closing_balance}. "
+                    f"Passing through — calculation stage will enforce tax treatment."
+                )
 
             # Check if this is a rights issue and if we should skip it
             is_rights_issue = sec_pos_obj in rights_issue_positions


### PR DESCRIPTION
## Summary

Fixes the crash on short stock positions (STK) such as CVNA or TSLA held short at year-end.

The importer previously clamped negative computed balances to zero and raised `ValueError` for any asset category other than OPT/FOP. This prevented processing of accounts with short stock positions.

Per the preferred architecture (enforcement at the calculation stage, not the importer), the importer now passes negative balances through for all asset types with a debug log. The calculation stage already handles them correctly: `price * quantity` with a negative quantity produces a negative CHF value in the Wertschriften section.

## Changes

- `src/opensteuerauszug/importers/ibkr/ibkr_importer.py`: remove clamp-to-zero and `ValueError` for negative balances; replace with a `logger.debug` that notes the negative and defers to the calculation stage

## Real-world validation

IBKR margin account, base currency CHF, Kanton Zug, tax year 2025:
- Short positions: CVNA (−1), TSLA (−5) at 31.12.2025
- Generated XML imported into eTax.Zug (Kanton Zug) without error
- Negative Wertschriften values accepted by cantonal software
- Net wealth matched IBKR NAV within CHF 150 (interest accruals + FX rounding)

Relates to: #309