### PR TITLE
fix: suppress spurious Kursliste warnings for fully-closed positions

### DIFF
--- a/src/opensteuerauszug/calculate/kursliste_tax_value_calculator.py
+++ b/src/opensteuerauszug/calculate/kursliste_tax_value_calculator.py
@@ -235,8 +235,15 @@ class KurslisteTaxValueCalculator(MinimalTaxValueCalculator):
                     "Suppressing missing Kursliste warning for option %s with zero balance.",
                     ident,
                 )
-                if closing_balance == 0:
-                    self._current_security_is_zero_balance_option = True
+                self._current_security_is_zero_balance_option = True
+            elif closing_balance == 0 and not security.payment:
+                # Security fully closed before year-end with no broker payments: no tax impact.
+                # If payments exist (e.g. dividends paid intra-year), keep the warning so the
+                # user knows Kursliste-based income enrichment was skipped.
+                logger.debug(
+                    "Suppressing missing Kursliste warning for %s with zero balance and no payments.",
+                    ident,
+                )
             else:
                 self._missing_kursliste_entries.append(ident)
 


### PR DESCRIPTION
## Summary

Securities traded intra-year but fully closed before 31 December generated "Kritische Warnungen" in the PDF despite having zero year-end tax impact. For accounts with active trading, this produced a large number of warnings requiring manual verification of each security.

This suppresses the warning when `closing_balance` is zero and the security has no broker payments. The `not security.payment` guard ensures securities with intra-year dividends still produce a warning — the Kursliste is needed for correct income enrichment in those cases (DA-1, withholding tax treatment).

## Changes

- `src/opensteuerauszug/calculate/kursliste_tax_value_calculator.py`:
  - Add `elif closing_balance == 0 and not security.payment` branch before the existing `else: self._missing_kursliste_entries.append(ident)`
  - Also clean up the existing `if closing_balance == 0` redundant guard in the zero-balance option branch (always true there)

## Real-world validation

IBKR margin account, base currency CHF, Kanton Zug, tax year 2025:
- 8 securities (AMPX, CRML, FIGR, KLAR, LDI, NEXT, NMAX, USAR) with zero year-end positions and no 2025 dividends
- All confirmed closed before 31.12.2025 via IBKR activity data; zero dividends confirmed via public records
- Before fix: 8 Kritische Warnungen in PDF; after fix: 0

Relates to: #261