### PR TITLE
Phase 2: Make calculate/ a hard gate for pyrefly type-checking

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -36,9 +36,7 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82,F401 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Type-check calculate/ with pyrefly
-      # Informational during Phase 0/1; remove continue-on-error in Phase 2 to gate.
-      continue-on-error: true
+    - name: Type-check calculate/ with pyrefly (gating from Phase 2)
       run: pyrefly check src/opensteuerauszug/calculate
     - name: Type-check full repo with pyrefly (informational)
       continue-on-error: true


### PR DESCRIPTION
## Summary

Phase 2 of the pyrefly type-checking rollout: remove `continue-on-error: true` from the calculate/ type-check CI step.

**Impact:** Any new type error in `src/opensteuerauszug/calculate/` will now block merges. The full-repo check (`src/`) remains informational.

## Changes

- Removed `continue-on-error: true` from the `Type-check calculate/ with pyrefly` step in `.github/workflows/python-app.yml`
- Updated step comment to reflect that calculate/ is now a hard gate (no longer informational)

## Verification

The calculate/ module is currently clean:
- pyrefly: 0 errors
- All 240 calculate tests passing
- All imports and type annotations fixed in Phase 1

## Next Steps

Phase 3 (categorize remaining ~188 full-repo errors) can proceed independently.

https://claude.ai/code/session_01HFCKK18cgWyAgYhSmUzvWT

---
_Generated by [Claude Code](https://claude.ai/code/session_01HFCKK18cgWyAgYhSmUzvWT)_