### PR TITLE
Fix type errors in model/ — pydantic-xml descriptor patterns and position caching

### DIFF
--- a/src/opensteuerauszug/model/ech0196.py
+++ b/src/opensteuerauszug/model/ech0196.py
@@ -1243,7 +1243,7 @@ class Security(BaseXmlModel):
     securityName: str = Field(..., max_length=60, json_schema_extra={'is_attribute': True})
     
     # Optional attributes
-    valorNumber: Optional[ValorNumber] = Field(default=None, json_schema_extra={'is_attribute': True})
+    valorNumber: Optional[ValorNumber] = Field(default=None, ge=ValorNumber(100), le=ValorNumber(999999999999), json_schema_extra={'is_attribute': True})
     isin: Optional[ISINType] = Field(default=None, pattern=r"[A-Z]{2}[A-Z0-9]{9}[0-9]{1}", json_schema_extra={'is_attribute': True})
     city: Optional[str] = Field(default=None, max_length=40, json_schema_extra={'is_attribute': True})
     nominalValue: Optional[Decimal] = Field(default=None, json_schema_extra={'is_attribute': True})

--- a/src/opensteuerauszug/model/ech0196.py
+++ b/src/opensteuerauszug/model/ech0196.py
@@ -304,7 +304,7 @@ class BaseXmlModel(BaseModel):
 
             value = getattr(self, field_name)
             field_path = f"{current_path}.{field_name}"
-            extra = field_info.json_schema_extra or {}
+            extra = field_info.json_schema_extra if isinstance(field_info.json_schema_extra, dict) else {}
 
             if extra.get("required_for_output") and value is None:
                 errors.append(f"{field_path} is required for final output but is None")
@@ -349,7 +349,7 @@ class BaseXmlModel(BaseModel):
         data = {}
         known_attrs = { field_info.alias or name
                         for name, field_info in cls.model_fields.items()
-                        if field_info.json_schema_extra and field_info.json_schema_extra.get("is_attribute") }
+                        if isinstance(field_info.json_schema_extra, dict) and field_info.json_schema_extra.get("is_attribute") }
         unknown_attrs = {}
         for name, value in element.attrib.items():
             # Find the field corresponding to this attribute name
@@ -426,7 +426,7 @@ class BaseXmlModel(BaseModel):
 
     def _build_attributes(self, element: ET._Element):
         for name, field_info in self.__class__.model_fields.items():
-            if field_info.json_schema_extra and field_info.json_schema_extra.get("is_attribute"):
+            if isinstance(field_info.json_schema_extra, dict) and field_info.json_schema_extra.get("is_attribute"):
                 value = getattr(self, name, None)
                 # print(f"Building attribute {name} with value {value}")
                 if value is not None:
@@ -484,7 +484,7 @@ class BaseXmlModel(BaseModel):
 
         for name, field_info in cls.model_fields.items():
             # Skip attributes
-            if field_info.json_schema_extra and field_info.json_schema_extra.get("is_attribute"):
+            if isinstance(field_info.json_schema_extra, dict) and field_info.json_schema_extra.get("is_attribute"):
                 continue
             # Skip fields to exclude at XML level
             if field_info.exclude:
@@ -711,7 +711,7 @@ class BaseXmlModel(BaseModel):
     def _build_children(self, parent_element: ET._Element):
         tag_map = {}
         for name, field_info in self.__class__.model_fields.items():
-            extra = field_info.json_schema_extra or {}
+            extra = field_info.json_schema_extra if isinstance(field_info.json_schema_extra, dict) else {}
             # Skip excluded fields and attributes
             if field_info.exclude or extra.get("is_attribute"):
                 continue
@@ -835,8 +835,8 @@ class BaseXmlModel(BaseModel):
             ValueError: If strict is True and unknown attributes or elements are encountered
         """
         # Determine strictness from parameter or class config
-        strict_mode = strict if strict is not None else cls.model_config.get('strict_parsing', False)
-        
+        strict_mode: bool = bool(strict if strict is not None else cls.model_config.get('strict_parsing', False))
+
         data = cls._parse_attributes(element, strict=strict_mode)
         data.update(cls._parse_children(element, strict=strict_mode))
         # Filter out internal fields before creating model instance
@@ -1243,7 +1243,7 @@ class Security(BaseXmlModel):
     securityName: str = Field(..., max_length=60, json_schema_extra={'is_attribute': True})
     
     # Optional attributes
-    valorNumber: Optional[ValorNumber] = Field(default=None, ge=100, le=999999999999, json_schema_extra={'is_attribute': True})
+    valorNumber: Optional[ValorNumber] = Field(default=None, json_schema_extra={'is_attribute': True})
     isin: Optional[ISINType] = Field(default=None, pattern=r"[A-Z]{2}[A-Z0-9]{9}[0-9]{1}", json_schema_extra={'is_attribute': True})
     city: Optional[str] = Field(default=None, max_length=40, json_schema_extra={'is_attribute': True})
     nominalValue: Optional[Decimal] = Field(default=None, json_schema_extra={'is_attribute': True})
@@ -1430,6 +1430,9 @@ class TaxStatementBase(BaseXmlModel):
             error_message = f"Validation error: {e}"
             logger.error(error_message)
             raise ValueError(error_message)
+
+    def to_xml_bytes(self) -> bytes:
+        raise NotImplementedError
 
 
 # Final root model including the minorVersion attribute

--- a/src/opensteuerauszug/model/kursliste.py
+++ b/src/opensteuerauszug/model/kursliste.py
@@ -965,14 +965,14 @@ class Kursliste(PydanticXmlModel, tag="kursliste", nsmap=NSMAP):
         Returns:
             List of securities with the matching valor number
         """
-        results = []
+        results: list[Security] = []
         for security_list in [
-            self.bonds, 
-            self.shares, 
-            self.funds, 
-            self.derivatives, 
-            self.coinBullions, 
-            self.currencyNotes, 
+            self.bonds,
+            self.shares,
+            self.funds,
+            self.derivatives,
+            self.coinBullions,
+            self.currencyNotes,
             self.liborSwaps
         ]:
             for security in security_list:
@@ -990,14 +990,14 @@ class Kursliste(PydanticXmlModel, tag="kursliste", nsmap=NSMAP):
         Returns:
             List of securities with the matching ISIN
         """
-        results = []
+        results: list[Security] = []
         for security_list in [
-            self.bonds, 
-            self.shares, 
-            self.funds, 
-            self.derivatives, 
-            self.coinBullions, 
-            self.currencyNotes, 
+            self.bonds,
+            self.shares,
+            self.funds,
+            self.derivatives,
+            self.coinBullions,
+            self.currencyNotes,
             self.liborSwaps
         ]:
             for security in security_list:

--- a/src/opensteuerauszug/model/position.py
+++ b/src/opensteuerauszug/model/position.py
@@ -1,5 +1,5 @@
 from typing import Optional, Union, Literal, Any
-from pydantic import BaseModel, Field, field_validator, PrivateAttr
+from pydantic import BaseModel, Field, field_validator
 
 from .ech0196 import ISINType, ValorNumber
 
@@ -11,7 +11,7 @@ class BasePosition(BaseModel):
         "arbitrary_types_allowed": True,
     }
 
-    def _comparison_key(self):
+    def _comparison_key(self) -> tuple:
         # To be overridden by subclasses for relevant fields
         return (self.depot,)
 
@@ -36,21 +36,18 @@ class CashPosition(BasePosition):
     currentCy: str = Field(default="USD", description="Currency code for cash position")
     cash_account_id: Optional[str] = Field(default=None, description="Optional identifier for a specific cash account within the same depot and currency")
     is_unsettled_balance: bool = Field(default=False, description="If True, this position holds cash that is in-transit (T+1 settlement pending)")
-    _identifier_str: Optional[str] = PrivateAttr(default=None)
 
     model_config = {
         "frozen": True,
         "arbitrary_types_allowed": True,
     }
 
-    def _comparison_key(self):
+    def _comparison_key(self) -> tuple:
         return (self.depot, self.currentCy, self.cash_account_id, self.is_unsettled_balance)
 
     def get_processing_identifier(self) -> str:
-        if self._identifier_str is None:
-            suffix = "-unsettled" if self.is_unsettled_balance else ""
-            self._identifier_str = f"Cash-{self.depot}-{self.cash_account_id}-{self.currentCy}{suffix}"
-        return self._identifier_str
+        suffix = "-unsettled" if self.is_unsettled_balance else ""
+        return f"Cash-{self.depot}-{self.cash_account_id}-{self.currentCy}{suffix}"
 
     def get_balance_name_prefix(self) -> str:
         return "Cash "
@@ -65,15 +62,12 @@ class SecurityPosition(BasePosition):
     symbol: str
     security_type: Optional[str] = Field(default=None, alias="securityType", description="Type of security, if available")
     description: Optional[str] = Field(default=None, description="Description of the security from the import file")
-    _identifier_str: Optional[str] = PrivateAttr(default=None)
 
-    def _comparison_key(self):
+    def _comparison_key(self) -> tuple:
         return (self.depot, self.valor, self.isin, self.symbol)
 
     def get_processing_identifier(self) -> str:
-        if self._identifier_str is None:
-            self._identifier_str = f"{self.depot}-{self.symbol}"
-        return self._identifier_str
+        return f"{self.depot}-{self.symbol}"
 
     def get_balance_name_prefix(self) -> str:
         return ""


### PR DESCRIPTION
## Summary

Fixes 19 pyrefly type errors across `src/opensteuerauszug/model/`.

### ech0196.py (12 fixes)

- **`json_schema_extra.get(...)` on FunctionType (6 sites):** `FieldInfo.json_schema_extra` is typed as `JsonDict | Callable | None`; a truthy check doesn't narrow it to `dict`, so calling `.get()` afterwards fails. Replaced `field_info.json_schema_extra or {}` with `isinstance(..., dict)` guards everywhere `.get()` is called on the result.

- **`bool | object` not assignable to `bool | None` (2 sites):** `cls.model_config.get('strict_parsing', False)` returns `object` (ConfigDict values have no specific type). Annotated `strict_mode` as `bool` and wrapped the expression in `bool(...)`.

- **Redundant `ge`/`le` on `Optional[ValorNumber]` (1 field):** `ValorNumber` is already `Annotated[int, Field(ge=100, le=999999999999)]` — the constraints are baked into the type. Removed the duplicate `ge`/`le` from the `Field()` call on the optional field.

- **`TaxStatementBase` has no `to_xml_bytes` (1 site):** Added an abstract `to_xml_bytes(self) -> bytes` method to `TaxStatementBase` that raises `NotImplementedError`, matching the concrete implementation on `TaxStatement`.

### kursliste.py (2 fixes)

- **`list[Bond | ...]` not assignable to `list[Security]` (2 methods):** `find_securities_by_valor_number` and `find_securities_by_isin` accumulated subtypes into an untyped `results = []`, which pyrefly inferred as `list[Bond | ...]`. Added explicit `results: list[Security] = []` annotations.

### position.py (5 fixes)

- **`_comparison_key` bad override (2 classes):** Parent and child `_comparison_key` methods return tuples of different length/types. Added `-> tuple` return annotation to all three (parent + both children) to establish a consistent base type.

- **`_identifier_str` read-only + `str | None` return (2 classes × 2 errors):** `PrivateAttr` in a frozen model is treated as read-only; the deferred assignment pattern also prevents narrowing to `str`. Simplified `get_processing_identifier` in `CashPosition` and `SecurityPosition` to compute and return the string directly (the caching was over-optimization for trivial string formatting). Removed the unused `_identifier_str PrivateAttr` declarations.

## Test plan

- [ ] `pyrefly check src/opensteuerauszug/model` → 0 errors
- [ ] `pytest tests/` (excluding render/pypdf tests) → green
- [ ] `flake8 --select=E9,F63,F7,F82,F401` → 0 errors

https://claude.ai/code/session_01HFCKK18cgWyAgYhSmUzvWT

---
_Generated by [Claude Code](https://claude.ai/code/session_01HFCKK18cgWyAgYhSmUzvWT)_