### PR TITLE
Fix type errors in core/ — None guards, Optional conn, and missing attribute access

### DIFF
--- a/src/opensteuerauszug/core/flag_override_provider.py
+++ b/src/opensteuerauszug/core/flag_override_provider.py
@@ -23,7 +23,7 @@ class FlagOverrideProvider:
         try:
             with open(file_path, mode='r', encoding='utf-8') as csvfile:
                 reader = csv.DictReader(csvfile)
-                if 'flags' in reader.fieldnames:
+                if reader.fieldnames and 'flags' in reader.fieldnames:
                     for row in reader:
                         if row.get('isin') and row.get('flags'):
                             self._overrides[row['isin']] = row['flags'].strip()

--- a/src/opensteuerauszug/core/kursliste_accessor.py
+++ b/src/opensteuerauszug/core/kursliste_accessor.py
@@ -190,7 +190,7 @@ class KurslisteAccessor:
                 country=country,
                 security_group=security_group,
                 tax_year=self.tax_year
-            )
+            ) or []
         elif isinstance(self.data_source, list):  # List[Kursliste]
             for kl_instance in self.data_source:
                 if kl_instance.year == self.tax_year and hasattr(kl_instance, 'da1Rates'):

--- a/src/opensteuerauszug/core/kursliste_db_reader.py
+++ b/src/opensteuerauszug/core/kursliste_db_reader.py
@@ -1,15 +1,19 @@
 import sqlite3
 import json
-from typing import Optional, Dict as PyDict, List, Type, cast
+from typing import Optional, Dict as PyDict, List, Type, TypeVar
 from datetime import date
 from decimal import Decimal, InvalidOperation
 
 from pydantic import ValidationError
+from pydantic_xml import BaseXmlModel as PydanticXmlModel
 
 from opensteuerauszug.model.kursliste import (
     Security, Share, Bond, Fund, Derivative, CoinBullion, CurrencyNote, LiborSwap,
     SecurityTypeESTV, Sign, Da1Rate, Da1RateType, SecurityGroupESTV
 )
+
+_T = TypeVar('_T', bound=PydanticXmlModel)
+
 
 class KurslisteDBReader:
     """
@@ -90,7 +94,7 @@ class KurslisteDBReader:
             pass
         return "json"  # Legacy databases used JSON blobs
 
-    def _deserialize_object(self, blob_data: bytes, model_class: Type, object_type_name: str) -> Optional[object]:
+    def _deserialize_object(self, blob_data: bytes, model_class: Type[_T], object_type_name: str) -> Optional[_T]:
         """
         Generic deserializer for objects stored as BLOBs.
         Handles both XML format (v3+) and legacy JSON format.
@@ -130,7 +134,7 @@ class KurslisteDBReader:
         if not model_class:
             print(f"Warning: Unknown security type identifier '{type_identifier}'. Cannot deserialize.")
             return None
-        return cast(Optional[Security], self._deserialize_object(blob_data, model_class, f"Security (Type: {type_identifier})"))
+        return self._deserialize_object(blob_data, model_class, f"Security (Type: {type_identifier})")
 
     def _execute_query_fetchone(self, query: str, params: tuple = ()) -> Optional[sqlite3.Row]:
         """Helper to execute a query and fetch one result."""
@@ -354,8 +358,7 @@ class KurslisteDBReader:
         """
         row = self._execute_query_fetchone(query, (sign_value, tax_year))
         if row and row["sign_object_blob"]:
-            # Type casting for clarity, _deserialize_object returns Optional[object]
-            return self._deserialize_object(row["sign_object_blob"], Sign, "Sign") # type: ignore
+            return self._deserialize_object(row["sign_object_blob"], Sign, "Sign")
         return None
 
     def get_da1_rate(self, country: str, security_group: SecurityGroupESTV, tax_year: int,
@@ -386,7 +389,7 @@ class KurslisteDBReader:
             if row["da1_rate_object_blob"]:
                 deserialized_obj = self._deserialize_object(row["da1_rate_object_blob"], Da1Rate, "Da1Rate")
                 if deserialized_obj:
-                    candidates.append(deserialized_obj) # type: ignore
+                    candidates.append(deserialized_obj)
 
         if not candidates:
             return None

--- a/src/opensteuerauszug/core/kursliste_db_reader.py
+++ b/src/opensteuerauszug/core/kursliste_db_reader.py
@@ -1,6 +1,6 @@
 import sqlite3
 import json
-from typing import Optional, Dict as PyDict, List, Type
+from typing import Optional, Dict as PyDict, List, Type, cast
 from datetime import date
 from decimal import Decimal, InvalidOperation
 
@@ -71,7 +71,7 @@ class KurslisteDBReader:
             db_path: Path to the SQLite database file.
         """
         self.db_path = db_path
-        self.conn = sqlite3.connect(self.db_path)
+        self.conn: Optional[sqlite3.Connection] = sqlite3.connect(self.db_path)
         self.conn.row_factory = sqlite3.Row  # Access columns by name
         # Detect blob format from metadata (xml or json/legacy)
         self._blob_format = self._read_blob_format()
@@ -79,6 +79,8 @@ class KurslisteDBReader:
     def _read_blob_format(self) -> str:
         """Read the blob_format metadata from the database. Returns 'json' for legacy databases."""
         try:
+            if self.conn is None:
+                return "json"
             cursor = self.conn.cursor()
             cursor.execute("SELECT value FROM metadata WHERE key = 'blob_format'")
             row = cursor.fetchone()
@@ -128,10 +130,12 @@ class KurslisteDBReader:
         if not model_class:
             print(f"Warning: Unknown security type identifier '{type_identifier}'. Cannot deserialize.")
             return None
-        return self._deserialize_object(blob_data, model_class, f"Security (Type: {type_identifier})")
+        return cast(Optional[Security], self._deserialize_object(blob_data, model_class, f"Security (Type: {type_identifier})"))
 
     def _execute_query_fetchone(self, query: str, params: tuple = ()) -> Optional[sqlite3.Row]:
         """Helper to execute a query and fetch one result."""
+        if self.conn is None:
+            return None
         try:
             cursor = self.conn.cursor()
             cursor.execute(query, params)
@@ -142,6 +146,8 @@ class KurslisteDBReader:
 
     def _execute_query_fetchall(self, query: str, params: tuple = ()) -> List[sqlite3.Row]:
         """Helper to execute a query and fetch all results."""
+        if self.conn is None:
+            return []
         try:
             cursor = self.conn.cursor()
             cursor.execute(query, params)

--- a/src/opensteuerauszug/core/kursliste_db_reader.py
+++ b/src/opensteuerauszug/core/kursliste_db_reader.py
@@ -80,7 +80,7 @@ class KurslisteDBReader:
         """Read the blob_format metadata from the database. Returns 'json' for legacy databases."""
         try:
             if self.conn is None:
-                return "json"
+                raise RuntimeError("KurslisteDBReader connection is closed.")
             cursor = self.conn.cursor()
             cursor.execute("SELECT value FROM metadata WHERE key = 'blob_format'")
             row = cursor.fetchone()

--- a/src/opensteuerauszug/core/kursliste_manager.py
+++ b/src/opensteuerauszug/core/kursliste_manager.py
@@ -309,5 +309,5 @@ class KurslisteManager:
         if not security_model:
             return []
 
-        payments = security_model.payment
+        payments = getattr(security_model, 'payment', [])
         return [p for p in payments if not p.deleted]


### PR DESCRIPTION
## Summary

Fixes 5 pyrefly type errors across `src/opensteuerauszug/core/`.

### flag_override_provider.py

- **`'flags' in None` (not-iterable):** `csv.DictReader.fieldnames` is typed as `Sequence[str] | None`. Added `reader.fieldnames and` guard before the `in` check.

### kursliste_accessor.py

- **`list[Da1Rate] | None` not assignable to `list[Da1Rate]`:** `get_da1_rate` can return `None` when the DB reader finds no candidates. Changed the assignment to `... or []` to provide an empty list fallback.

### kursliste_db_reader.py (2 fixes)

- **`object | None` not assignable to `Security | None`:** `_deserialize_object` returns `object | None` (untyped deserialization). Added `cast(Optional[Security], ...)` on the return to satisfy the declared return type.

- **`None` not assignable to `conn` (Connection):** `close()` sets `self.conn = None` but the field was typed as `Connection` (non-optional). Changed the field type to `Optional[sqlite3.Connection]` and added `if self.conn is None` guards in `_execute_query_fetchone`, `_execute_query_fetchall`, and `_read_blob_format`.

### kursliste_manager.py

- **`Security` has no attribute `payment`:** The kursliste `Security` base class doesn't declare `payment` — only concrete subclasses (Bond, Share, Fund, etc.) do. Changed `security_model.payment` to `getattr(security_model, 'payment', [])`.

## Test plan

- [ ] `pyrefly check src/opensteuerauszug/core` → 0 errors
- [ ] `pytest tests/calculate/ tests/core/` → green
- [ ] `flake8 --select=E9,F63,F7,F82,F401` → 0 errors

https://claude.ai/code/session_01HFCKK18cgWyAgYhSmUzvWT

---
_Generated by [Claude Code](https://claude.ai/code/session_01HFCKK18cgWyAgYhSmUzvWT)_