### PR TITLE
Make pyrefly check src/ a hard CI gate

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -36,10 +36,7 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82,F401 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Type-check calculate/ with pyrefly (gating from Phase 2)
-      run: pyrefly check src/opensteuerauszug/calculate
-    - name: Type-check full repo with pyrefly (informational)
-      continue-on-error: true
+    - name: Type-check with pyrefly
       run: pyrefly check src
     - name: Test with pytest
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,11 +81,8 @@ markers = [
     "integration: marks tests as integration tests",
 ]
 
-# Type checking with pyrefly. Scope is everything under src/; CI invokes
-# pyrefly twice — once on src/opensteuerauszug/calculate (gating from
-# Phase 2) and once on src/ as a whole (informational). Per-module
-# severity overrides are deferred until Phase 3 once the full-repo
-# error landscape is categorized.
+# Type checking with pyrefly. Scope is everything under src/; CI gates
+# on the full src/ tree.
 [tool.pyrefly]
 project-includes = ["src/opensteuerauszug"]
 project-excludes = ["**/.venv/**", "**/build/**", "**/dist/**", "tests/**"]


### PR DESCRIPTION
## Summary

Promotes pyrefly to a hard CI gate on the full `src/` tree.

With type fixes for `model/`, `core/`, `importers/`, `render/`, and `steuerauszug.py` all merged, `pyrefly check src` reports 0 errors (8 suppressed for third-party stub limitations). The two-step CI (calculate/ gating + full-repo informational) is now collapsed into a single gating check, and the stale rollout comment in `pyproject.toml` is updated.

## Test plan

- [x] `pyrefly check src` → 0 errors locally
- [x] CI workflow now fails any new type error introduced anywhere under `src/`

https://claude.ai/code/session_01HFCKK18cgWyAgYhSmUzvWT

---
_Generated by [Claude Code](https://claude.ai/code/session_01HFCKK18cgWyAgYhSmUzvWT)_