### PR TITLE
[codex] Handle Schwab lapse awards

### DIFF
--- a/src/opensteuerauszug/importers/schwab/position_extractor.py
+++ b/src/opensteuerauszug/importers/schwab/position_extractor.py
@@ -52,7 +52,10 @@ class PositionExtractor:
         positions: List[Tuple[Position, SecurityStock]] = []
         for row in reader:
             symbol = row.get('Symbol', '').strip()
-            security_type = row.get('Security Type', '').strip() or row.get('Security Type', '').strip()
+            security_type = (
+                row.get('Security Type', '').strip()
+                or row.get('Asset Type', '').strip()
+            )
             qty_str = row.get('Qty (Quantity)', '').replace(',', '').strip()
             mkt_val_str = row.get('Mkt Val (Market Value)', '').replace(',', '').replace('$', '').strip()
             description = row.get('Description', '').strip() if 'Description' in row else None
@@ -110,4 +113,4 @@ if __name__ == "__main__":
         import pprint
         pprint.pprint(result)
     else:
-        print("File is not a valid Schwab positions CSV or could not extract positions.") 
+        print("File is not a valid Schwab positions CSV or could not extract positions.")

--- a/src/opensteuerauszug/importers/schwab/transaction_extractor.py
+++ b/src/opensteuerauszug/importers/schwab/transaction_extractor.py
@@ -17,7 +17,7 @@ KNOWN_ACTIONS = {
     "Full Redemption", "Full Redemption Adj", "Foreign Tax Paid", "Funds Received", "IRS Withhold Adj", "Long Term Cap Gain",
     "Misc Cash Entry", "MoneyLink Adj", "MoneyLink Deposit", "MoneyLink Transfer",
     "NRA Tax Adj", "NRA Withholding", "Non-Qualified Div", "Qualified Dividend", "Reinvest Dividend", "Qual Div Reinvest", "Reinvest Shares", "Sale", "Sell",
-    "Service Fee", "Short Term Cap Gain", "Special Qual Div", "Spin-off", "Stock Plan Activity", "Stock Split",
+    "Lapse", "Service Fee", "Short Term Cap Gain", "Special Qual Div", "Spin-off", "Stock Plan Activity", "Stock Split",
     "Visa Purchase", "Wire Funds", "Wire Funds Received", "Wire Sent",
     "Tax Reversal", "Tax Withholding", "Transfer", "Security Transfer", "Wire Transfer"
 }
@@ -347,6 +347,39 @@ class TransactionExtractor:
                 )
                 # Stock Plan Activity usually has no direct cash flow in the brokerage account (it's the vesting)
                 # Any cash flow (taxes) is usually handled by separate Journal or Tax Withholding entries.
+
+        elif action == "Lapse":
+            if not isinstance(pos_object, SecurityPosition) or pos_object.depot != "AWARDS":
+                raise ValueError(f"Lapse action is only handled for the Equity Awards depot: {schwab_tx}")
+            if schwab_amount is not None and schwab_amount != 0:
+                raise ValueError(f"Lapse action should not carry a cash amount: {schwab_tx}")
+
+            # Equity Awards Center uses "Lapse" for vesting, with
+            # TransactionDetails splitting the vested quantity into withheld
+            # and net-deposited shares. In setups where Schwab automatically
+            # transfers awards into the Individual account, the net shares are
+            # reported there as "Stock Plan Activity"; importing both rows
+            # would double count the position.
+            details = {}
+            transaction_details = schwab_tx.get("TransactionDetails") or []
+            if transaction_details:
+                details = transaction_details[0].get("Details", {}) or {}
+            net_shares = self._parse_schwab_decimal(details.get("NetSharesDeposited"))
+            shares_withheld = (
+                self._parse_schwab_decimal(details.get("SharesSoldWithheldForTaxes"))
+                or Decimal("0")
+            )
+            if schwab_qty is not None and net_shares is not None:
+                expected_qty = net_shares + shares_withheld
+                if schwab_qty != expected_qty:
+                    logger.warning(
+                        "Ignoring Schwab Equity Awards Lapse with quantity %s, but "
+                        "NetSharesDeposited + SharesSoldWithheldForTaxes is %s: %s",
+                        schwab_qty,
+                        expected_qty,
+                        schwab_tx,
+                    )
+            return None, None, None
 
         elif action == "Credit Interest":
             # Generates a Payment for the cash account AND a cash stock mutation

--- a/tests/importers/schwab/test_position_extractor.py
+++ b/tests/importers/schwab/test_position_extractor.py
@@ -41,6 +41,31 @@ def test_extract_positions_valid():
     assert stock1.balanceCurrency == 'USD'
     assert stock2.balanceCurrency == 'USD'
 
+def test_asset_type_column_identifies_security_positions():
+    csv_content = (
+        '"Positions for account Individual ...632 as of 02:19 PM ET, 2026/05/11"\n'
+        '\n'
+        '"Symbol","Description","Qty (Quantity)","Price","Price Chng $ (Price Change $)","Price Chng % (Price Change %)","Mkt Val (Market Value)","Day Chng $ (Day Change $)","Day Chng % (Day Change %)","Cost Basis","Gain $ (Gain/Loss $)","Gain % (Gain/Loss %)","Reinvest?","Reinvest Capital Gains?","Asset Type"\n'
+        '"META","META PLATFORMS INC CLASS CLASS A","111","601.2701","-8.3599","-1.37%","$66,740.98","-$927.95","-1.37%","$76,053.86","-$9,312.88","-12.25%","No","N/A","Equity"\n'
+    )
+    with tempfile.NamedTemporaryFile(mode='w+', delete=False, suffix='.csv') as tmp:
+        tmp.write(csv_content)
+        tmp.flush()
+        extractor = PositionExtractor(tmp.name)
+        result = extractor.extract_positions()
+    os.unlink(tmp.name)
+
+    assert result is not None
+    positions, statement_date, depot = result
+    assert depot == '632'
+    assert statement_date.isoformat() == '2026-05-12'
+    assert len(positions) == 1
+    pos, stock = positions[0]
+    assert isinstance(pos, SecurityPosition)
+    assert pos.symbol == 'META'
+    assert pos.security_type == 'Equity'
+    assert stock.quantity == 111
+
 def test_extract_positions_invalid():
     with tempfile.NamedTemporaryFile(mode='w+', delete=False, suffix='.csv') as tmp:
         tmp.write(BAD_CSV)
@@ -48,4 +73,4 @@ def test_extract_positions_invalid():
         extractor = PositionExtractor(tmp.name)
         result = extractor.extract_positions()
     os.unlink(tmp.name)
-    assert result is None 
+    assert result is None

--- a/tests/importers/schwab/test_transaction_extractor.py
+++ b/tests/importers/schwab/test_transaction_extractor.py
@@ -1050,6 +1050,79 @@ class TestSchwabTransactionExtractor:
         assert stock.unitPrice is None
         assert stock.name == "Stock Plan Activity"
 
+    def test_equity_awards_lapse_is_ignored_when_net_shares_are_deposited_elsewhere(self):
+        extractor = create_extractor()
+        data = {
+            "FromDate": "01/01/2025",
+            "ToDate": "12/31/2025",
+            "Transactions": [{
+                "Date": "11/15/2025",
+                "Action": "Lapse",
+                "Symbol": "ACME",
+                "Quantity": "3",
+                "Description": "Restricted Stock Lapse",
+                "FeesAndCommissions": None,
+                "DisbursementElection": None,
+                "Amount": None,
+                "TransactionDetails": [{
+                    "Details": {
+                        "AwardDate": "02/10/2025",
+                        "AwardId": "AWARD-001",
+                        "FairMarketValuePrice": "$123.45",
+                        "SalePrice": "",
+                        "SharesSoldWithheldForTaxes": "1",
+                        "NetSharesDeposited": "2",
+                        "Taxes": "$98.76",
+                    }
+                }],
+            }],
+        }
+
+        assert extractor._extract_transactions_from_dict(data) is None
+
+    def test_equity_awards_lapse_allows_missing_withheld_tax_shares(self):
+        extractor = create_extractor()
+        data = {
+            "FromDate": "01/01/2025",
+            "ToDate": "12/31/2025",
+            "Transactions": [{
+                "Date": "11/15/2025",
+                "Action": "Lapse",
+                "Symbol": "ACME",
+                "Quantity": "2",
+                "Description": "Restricted Stock Lapse",
+                "Amount": None,
+                "TransactionDetails": [{
+                    "Details": {
+                        "AwardDate": "02/10/2025",
+                        "AwardId": "AWARD-002",
+                        "FairMarketValuePrice": "$123.45",
+                        "NetSharesDeposited": "2",
+                    }
+                }],
+            }],
+        }
+
+        assert extractor._extract_transactions_from_dict(data) is None
+
+    def test_brokerage_lapse_is_not_silently_ignored(self):
+        extractor = create_extractor()
+        data = {
+            "FromDate": "01/01/2025",
+            "ToDate": "12/31/2025",
+            "BrokerageTransactions": [{
+                "Date": "11/15/2025",
+                "Action": "Lapse",
+                "Symbol": "ACME",
+                "Quantity": "3",
+                "Description": "Restricted Stock Lapse",
+                "Amount": None,
+            }],
+        }
+
+        with pytest.raises(ValueError, match="only handled for the Equity Awards depot"):
+            extractor._extract_transactions_from_dict(data)
+
     def test_action_tax_reversal(self):
         """Tax Reversal with positive amount records a negative nonRecoverableTax (offsetting prior withholding)."""
         extractor = create_extractor()


### PR DESCRIPTION
## Summary

- Treat Schwab Equity Awards `Lapse` transactions as explicit no-ops when net shares are deposited through the brokerage account as `Stock Plan Activity`.
- Allow `SharesSoldWithheldForTaxes` to be absent on `Lapse` payloads by treating the withheld share count as zero for consistency checking.
- Parse Schwab positions CSVs that use `Asset Type` instead of `Security Type`, so security balances are not skipped.

Fixes #397.

## Root Cause

The Schwab importer rejected `Lapse` actions from Equity Awards Center JSON as unknown. After that was handled, the sample still failed reconciliation because the positions CSV security row used `Asset Type`, while the parser only looked for `Security Type`, so the future balance needed for backward reconciliation was skipped.

## Validation

- `pytest tests/importers/schwab/test_transaction_extractor.py tests/importers/schwab/test_position_extractor.py`
- `flake8 src/opensteuerauszug/importers/schwab/transaction_extractor.py src/opensteuerauszug/importers/schwab/position_extractor.py tests/importers/schwab/test_transaction_extractor.py tests/importers/schwab/test_position_extractor.py`
- End-to-end Schwab command with explicit output path completed successfully locally.