### PR TITLE
[codex] Fix Schwab unsettled cash period boundary

### DIFF
--- a/src/opensteuerauszug/importers/schwab/schwab_importer.py
+++ b/src/opensteuerauszug/importers/schwab/schwab_importer.py
@@ -74,16 +74,19 @@ def split_unsettled_cash(
 ) -> Tuple[List[SecurityStock], List[SecurityStock]]:
     """Partition *stocks* into settled and unsettled at *period_end*.
 
-    For every T+1 mutation (``requires_settlement=True``) that settles within
-    the period, the mutation's ``referenceDate`` is unconditionally shifted to
-    the settlement date.  Cash moves on settlement day, not trade day, so this
-    is the semantically correct date for cash-account entries.  It also
+    For every T+1 mutation (``requires_settlement=True``) that does not cross
+    the period-end boundary, the mutation's ``referenceDate`` is shifted to the
+    settlement date.  Cash moves on settlement day, not trade day, so this is
+    the semantically correct date for cash-account entries.  It also
     naturally handles intra-period balance checkpoints: because balance entries
     sort before mutations on the same date, a settlement-dated mutation always
     appears *after* any same-day balance snapshot in the reconciler's sequence.
 
-    Mutations that settle strictly after *period_end* are placed in the
-    unsettled bucket; the caller reports them as a separate account.
+    Mutations traded on or before *period_end* that settle strictly after
+    *period_end* are placed in the unsettled bucket; the caller reports them as
+    a separate account.  Future trades from an export that extends past the tax
+    year are kept in the settled timeline so backward reconciliation from a
+    later balance snapshot can un-apply them.
 
     Balance entries (mutation=False) and non-settlement mutations are placed
     in the settled bucket unchanged.
@@ -100,11 +103,13 @@ def split_unsettled_cash(
     for s in stocks:
         if s.mutation and s.requires_settlement:
             settle = settlement_date(s.referenceDate)
-            if settle > period_end:
+            if s.referenceDate <= period_end < settle:
                 # Will not settle within the period → separate unsettled account.
                 unsettled.append(s)
             else:
-                # Always date cash at settlement, not trade date.
+                # Date cash at settlement, not trade date.  Future trades remain
+                # in the main timeline so synthesis for the period end can work
+                # backwards from a later position snapshot.
                 settled.append(s.model_copy(update={"referenceDate": settle}))
         else:
             settled.append(s)

--- a/tests/importers/schwab/test_schwab_importer.py
+++ b/tests/importers/schwab/test_schwab_importer.py
@@ -607,6 +607,17 @@ class TestSplitUnsettledCash(unittest.TestCase):
         self.assertEqual(len(unsettled), 1)
         self.assertEqual(unsettled[0].quantity, Decimal("1000"))
 
+    def test_future_trade_after_period_end_is_not_unsettled_for_period_end(self):
+        # A Schwab export can include transactions after the requested tax year.
+        # Those future trades must remain in the main cash timeline for backward
+        # reconciliation from a later balance snapshot; they are not unsettled
+        # cash at the previous year end.
+        stocks = [self._bal("2026-05-12", "48712.34"), self._mut("2026-02-24", "48109.87")]
+        settled, unsettled = split_unsettled_cash(stocks, date(2025, 12, 31))
+        self.assertEqual(unsettled, [])
+        self.assertEqual(len(settled), 2)
+        self.assertEqual(settled[1].referenceDate, date(2026, 2, 25))
+
     def test_split_mixed(self):
         stocks = [
             self._bal("2025-01-01", "0"),


### PR DESCRIPTION
## Summary

Fixes Schwab cash settlement splitting so transactions after the requested tax year are not reported as unsettled cash at the prior year end.

## Root Cause

Schwab transaction exports can extend beyond the tax year while the importer still synthesizes the year-end cash position from a later balance snapshot. The unsettled-cash splitter classified any trade whose settlement date was after the tax period end as unsettled, including trades executed after the tax year. That caused future sale proceeds to appear as a separate unsettled 2025 cash account.

## Changes

- Only classify a trade as period-end unsettled cash when the trade date is on or before the period end and the settlement date crosses the period end.
- Keep post-period trades in the main cash timeline so backward reconciliation can un-apply them from later Schwab balance snapshots.
- Added a regression test with anonymized, realistic cash/proceeds values to cover future trades from extended Schwab exports.

## Validation

- `pytest tests/importers/schwab/test_schwab_importer.py`
- `python -m pytest tests/importers/common/test_postprocess.py`
- Re-ran the Schwab sample command locally and confirmed the spurious unsettled account disappeared from the generated XML.