### PR TITLE
Support bond interest in IBKR importer and raise hard error in Kursliste calculator (#407)

### DIFF
--- a/src/opensteuerauszug/calculate/kursliste_tax_value_calculator.py
+++ b/src/opensteuerauszug/calculate/kursliste_tax_value_calculator.py
@@ -162,6 +162,11 @@ class KurslisteTaxValueCalculator(MinimalTaxValueCalculator):
         return result
 
     def _handle_Security(self, security: Security, path_prefix: str) -> None:
+        if security.securityCategory == "BOND":
+            raise ValueError(
+                f"Bonds are not supported (refer to issue #262). Found bond security: {security.securityName} ({security.isin or security.valorNumber})"
+            )
+
         self._current_kursliste_security = None
         self._current_security_is_zero_balance_option = False
 

--- a/src/opensteuerauszug/importers/ibkr/ibkr_importer.py
+++ b/src/opensteuerauszug/importers/ibkr/ibkr_importer.py
@@ -898,7 +898,10 @@ class IbkrImporter:
                     if security_id:
                         tx_type_str = tx_type.value
                         tx_type_str_lower = str(tx_type_str).lower()
-                        assert 'interest' not in tx_type_str_lower
+                        asset_category = getattr(cash_tx, 'assetCategory', None)
+                        # We assert that we do not book general broker/cash interest accidentally under a security.
+                        # However, bond interest is fine at import time (assetCategory == "BOND").
+                        assert 'interest' not in tx_type_str_lower or asset_category == 'BOND'
 
                         sec_pos_key = self._find_processed_security_position(
                             processed_security_positions,
@@ -914,6 +917,11 @@ class IbkrImporter:
                                 cash_tx,
                                 description,
                             )
+
+                        if asset_category:
+                            sub_category = getattr(cash_tx, 'subCategory', None)
+                            if sec_pos_key not in security_asset_category_map:
+                                security_asset_category_map[sec_pos_key] = (asset_category, sub_category)
 
                         # Update name metadata (Priority: 0 for CashTransactions - lowest)
                         # Use description or symbol if description is generic?

--- a/tests/calculate/test_kursliste_tax_value_calculator.py
+++ b/tests/calculate/test_kursliste_tax_value_calculator.py
@@ -2534,3 +2534,26 @@ def test_compute_payments_single_variant_does_not_raise(kursliste_manager):
     # Should not raise - only one variant value present
     calc.computePayments(sec, "sec")
     assert len(sec.payment) == 1
+
+
+def test_kursliste_calculator_fails_on_bond_security(kursliste_manager):
+    """Verify that a security with securityCategory='BOND' causes a ValueError referring to issue #262."""
+    provider = KurslisteExchangeRateProvider(kursliste_manager)
+    calc = KurslisteTaxValueCalculator(mode=CalculationMode.FILL, exchange_rate_provider=provider)
+
+    security = Security(
+        country="US",
+        securityName="US Treasury Bond",
+        positionId=1,
+        currency="USD",
+        quotationType="PIECE",
+        securityCategory="BOND",
+        isin=ISINType("US91282CHT18"),
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        calc._handle_Security(security, "security")
+
+    assert "Bonds are not supported" in str(excinfo.value)
+    assert "#262" in str(excinfo.value)
+

--- a/tests/importers/ibkr/test_ibkr_importer.py
+++ b/tests/importers/ibkr/test_ibkr_importer.py
@@ -2969,3 +2969,60 @@ def test_ibkr_corrections_flex_skips_out_of_period_transactions(sample_ibkr_sett
     finally:
         os.remove(main_path)
         os.remove(corr_path)
+
+
+SAMPLE_IBKR_FLEX_XML_BOND_INTEREST = """
+<FlexQueryResponse queryName="BondInterest" type="AF">
+  <FlexStatements count="1">
+    <FlexStatement accountId="U1234567" fromDate="2023-01-01" toDate="2023-12-31" period="Year" whenGenerated="2024-01-15T10:00:00">
+      <CashTransactions>
+        <CashTransaction accountId="U1234567" acctAlias="" model="" currency="USD" fxRateToBase="1" assetCategory="BOND" subCategory="Govt" symbol="T 3 7/8 08/15/33" description="BOND COUPON PAYMENT (T 3 7/8 08/15/33 - United States Treasury T 3 7/8 08/15/33)" conid="647589171" securityID="US91282CHT18" securityIDType="ISIN" cusip="91282CHT1" isin="US91282CHT18" figi="BBG01HQWRSG4" listingExchange="" underlyingConid="" underlyingSymbol="T" underlyingSecurityID="" underlyingListingExchange="" issuer="" issuerCountryCode="US" multiplier="1" strike="" expiry="" putCall="" principalAdjustFactor="1" dateTime="2023-02-17" settleDate="2023-02-17" availableForTradingDate="" amount="1937.5" type="Bond Interest Received" dividendType="" tradeID="" code="" transactionID="38088293515" reportDate="2023-02-18" exDate="" clientReference="" actionID="" levelOfDetail="DETAIL" serialNumber="" deliveryType="" commodityType="" fineness="0.0" weight="0.0" />
+      </CashTransactions>
+      <CashReport>
+        <CashReportCurrency accountId="U1234567" currency="USD" endingCash="1937.5" fromDate="2023-01-01" toDate="2023-12-31" />
+      </CashReport>
+    </FlexStatement>
+  </FlexStatements>
+</FlexQueryResponse>
+"""
+
+
+def test_bond_interest_import_succeeds(sample_ibkr_settings):
+    """Importing bond interest cash transactions should succeed and create a BOND security."""
+    period_from = date(2023, 1, 1)
+    period_to = date(2023, 12, 31)
+
+    importer = IbkrImporter(
+        period_from=period_from,
+        period_to=period_to,
+        account_settings_list=sample_ibkr_settings,
+    )
+
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".xml") as tmp_file:
+        tmp_file.write(SAMPLE_IBKR_FLEX_XML_BOND_INTEREST)
+        xml_file_path = tmp_file.name
+
+    try:
+        statement = importer.import_files([xml_file_path])
+        assert statement is not None
+
+        # Verify the security of category BOND was created
+        securities = [
+            s for d in statement.listOfSecurities.depot
+            for s in d.security
+        ]
+        assert len(securities) == 1
+        bond_sec = securities[0]
+        assert bond_sec.securityCategory == "BOND"
+        assert bond_sec.isin == "US91282CHT18"
+        assert bond_sec.securityName == "BOND COUPON PAYMENT (T 3 7/8 ...08/15/33) (T 3 7/8 08/15/33)"
+
+        # Verify the bond interest payment was correctly created
+        assert len(bond_sec.payment) == 1
+        payment = bond_sec.payment[0]
+        assert payment.amount == Decimal("1937.5")
+        assert payment.amountCurrency == "USD"
+        assert payment.paymentDate == date(2023, 2, 17)
+    finally:
+        if os.path.exists(xml_file_path):
+            os.remove(xml_file_path)


### PR DESCRIPTION
This PR resolves issue #407. It:
1. Relaxes the IBKR importer's interest assertion to allow bond interest transactions (where the cash transaction's `assetCategory` is `BOND`).
2. Populates `security_asset_category_map` from cash transactions so that securities without associated trades or open positions are correctly classified as `BOND`.
3. Adds a hard error in the Kursliste calculator (`KurslisteTaxValueCalculator`) referring to issue #262 when encountering a security of category `BOND`.
4. Adds new tests verifying both the successful import of bond interest and the expected ValueError in the Kursliste calculator.