### PR TITLE
Support European number formats in Degiro CSV imports

### DIFF
--- a/src/opensteuerauszug/importers/degiro/_number.py
+++ b/src/opensteuerauszug/importers/degiro/_number.py
@@ -1,0 +1,34 @@
+"""Number-parsing helpers for the Degiro importer.
+
+Degiro CSV exports use the locale-specific number formatting of the user's
+account language: English exports use ``1234.56`` while German/Italian/French
+exports use ``1.234,56`` (or quoted ``"3487,66"``).  These helpers normalise
+both styles to a plain ``Decimal``-compatible string before parsing.
+"""
+
+from decimal import Decimal
+
+from opensteuerauszug.importers.common.parsing import to_decimal
+
+
+def normalize_number(s: str) -> str:
+    """Strip thousands separators and convert decimal commas to dots.
+
+    Handles:
+      * Swiss/Italian style with apostrophe thousands: ``1'000.50``
+      * English/US style with comma thousands: ``1,000.50``
+      * German/French style with dot thousands and comma decimal: ``1.000,50``
+      * Plain European decimal comma: ``3487,66``
+    """
+    if "," in s and "." in s:
+        if s.rindex(",") > s.rindex("."):
+            return s.replace(".", "").replace(",", ".")
+        return s.replace(",", "")
+    if "," in s:
+        return s.replace(",", ".")
+    return s.replace("'", "")
+
+
+def to_decimal_localized(value: str, field_name: str, context: str) -> Decimal:
+    """Like ``to_decimal`` but tolerant of European number formats."""
+    return to_decimal(normalize_number(value), field_name, context)

--- a/src/opensteuerauszug/importers/degiro/account_csv_parser.py
+++ b/src/opensteuerauszug/importers/degiro/account_csv_parser.py
@@ -17,7 +17,7 @@ from decimal import Decimal
 from enum import Enum, auto
 from typing import Optional
 
-from opensteuerauszug.importers.common.parsing import to_decimal
+from ._number import to_decimal_localized as to_decimal
 
 ACCOUNT_CSV_FIELDNAMES = [
     "Date",

--- a/src/opensteuerauszug/importers/degiro/account_csv_parser.py
+++ b/src/opensteuerauszug/importers/degiro/account_csv_parser.py
@@ -17,7 +17,7 @@ from decimal import Decimal
 from enum import Enum, auto
 from typing import Optional
 
-from ._number import to_decimal_localized as to_decimal
+from ._number import to_decimal_localized
 
 ACCOUNT_CSV_FIELDNAMES = [
     "Date",
@@ -184,16 +184,16 @@ def load_account_csv(path: str) -> list[DegiroRow]:
                 continue
             vd_str = raw.get("Value date", "").strip()
             fx_str = raw.get("FX", "").strip()
-            fx_rate = to_decimal(fx_str, "FX", f"row {row_num}") if fx_str else None
+            fx_rate = to_decimal_localized(fx_str, "FX", f"row {row_num}") if fx_str else None
             change_str = raw.get("Change_amount", "").strip()
             change_amount = (
-                to_decimal(change_str, "Change_amount", f"row {row_num}")
+                to_decimal_localized(change_str, "Change_amount", f"row {row_num}")
                 if change_str
                 else Decimal("0")
             )
             balance_str = raw.get("Balance_amount", "").strip()
             balance_amount = (
-                to_decimal(balance_str, "Balance_amount", f"row {row_num}")
+                to_decimal_localized(balance_str, "Balance_amount", f"row {row_num}")
                 if balance_str
                 else Decimal("0")
             )

--- a/src/opensteuerauszug/importers/degiro/degiro_importer.py
+++ b/src/opensteuerauszug/importers/degiro/degiro_importer.py
@@ -51,7 +51,7 @@ from opensteuerauszug.model.ech0196 import (
 )
 from opensteuerauszug.model.position import SecurityPosition
 
-from ._number import normalize_number as _normalize_number
+from ._number import normalize_number
 from .account_csv_parser import (
     DegiroRow,
     DegiroRowKind,
@@ -346,8 +346,8 @@ class DegiroImporter:
             return
 
         action, qty_str, _name, price_str, currency = m.groups()
-        qty = Decimal(_normalize_number(qty_str))
-        price = Decimal(_normalize_number(price_str))
+        qty = Decimal(normalize_number(qty_str))
+        price = Decimal(normalize_number(price_str))
 
         if action in ("Sell", "Vendita", "Vente", "Verkauf"):
             qty = -qty

--- a/src/opensteuerauszug/importers/degiro/degiro_importer.py
+++ b/src/opensteuerauszug/importers/degiro/degiro_importer.py
@@ -51,6 +51,7 @@ from opensteuerauszug.model.ech0196 import (
 )
 from opensteuerauszug.model.position import SecurityPosition
 
+from ._number import normalize_number as _normalize_number
 from .account_csv_parser import (
     DegiroRow,
     DegiroRowKind,
@@ -80,20 +81,6 @@ _ISIN_RE = re.compile(r"^[A-Z]{2}[A-Z0-9]{9}[0-9]$")
 
 def _valid_isin(isin: str) -> bool:
     return bool(_ISIN_RE.match(isin))
-
-
-def _normalize_number(s: str) -> str:
-    """Strip thousands separators (' and .) from a numeric string.
-
-    Handles Swiss/Italian style (1'000.50) and German style (1.000,50).
-    """
-    if "," in s and "." in s:
-        if s.rindex(",") > s.rindex("."):
-            return s.replace(".", "").replace(",", ".")
-        return s.replace(",", "")
-    if "," in s:
-        return s.replace(",", ".")
-    return s.replace("'", "")
 
 
 def _infer_category(product: str) -> SecurityCategory:

--- a/src/opensteuerauszug/importers/degiro/portfolio_csv_parser.py
+++ b/src/opensteuerauszug/importers/degiro/portfolio_csv_parser.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 from decimal import Decimal
 from typing import Optional
 
-from opensteuerauszug.importers.common.parsing import to_decimal
+from ._number import to_decimal_localized as to_decimal
 
 PORTFOLIO_CSV_FIELDNAMES = [
     "Product",

--- a/src/opensteuerauszug/importers/degiro/portfolio_csv_parser.py
+++ b/src/opensteuerauszug/importers/degiro/portfolio_csv_parser.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 from decimal import Decimal
 from typing import Optional
 
-from ._number import to_decimal_localized as to_decimal
+from ._number import to_decimal_localized
 
 PORTFOLIO_CSV_FIELDNAMES = [
     "Product",
@@ -52,22 +52,26 @@ def load_portfolio_csv(path: str) -> list[PortfolioEntry]:
             isin = raw.get("Symbol_ISIN", "").strip()
             amount_str = raw.get("Amount", "").strip()
             amount = (
-                to_decimal(amount_str, "Amount", f"row {row_num}") if amount_str else Decimal("0")
+                to_decimal_localized(amount_str, "Amount", f"row {row_num}")
+                if amount_str
+                else Decimal("0")
             )
             closing_str = raw.get("Closing", "").strip()
             closing_price = (
-                to_decimal(closing_str, "Closing", f"row {row_num}") if closing_str else None
+                to_decimal_localized(closing_str, "Closing", f"row {row_num}")
+                if closing_str
+                else None
             )
             local_currency = raw.get("Local_currency", "").strip()
             local_amount_str = raw.get("Local_amount", "").strip()
             local_amount = (
-                to_decimal(local_amount_str, "Local_amount", f"row {row_num}")
+                to_decimal_localized(local_amount_str, "Local_amount", f"row {row_num}")
                 if local_amount_str
                 else Decimal("0")
             )
             value_chf_str = raw.get("Value_CHF", "").strip()
             value_chf = (
-                to_decimal(value_chf_str, "Value_CHF", f"row {row_num}")
+                to_decimal_localized(value_chf_str, "Value_CHF", f"row {row_num}")
                 if value_chf_str
                 else Decimal("0")
             )

--- a/tests/importers/degiro/test_degiro_account_parser.py
+++ b/tests/importers/degiro/test_degiro_account_parser.py
@@ -210,6 +210,31 @@ def test_load_account_csv_raw_row_numbers(tmp_path):
     assert rows[1].raw_row == 3
 
 
+SAMPLE_ACCOUNT_CSV_EU = """\
+Date,Time,Value date,Product,ISIN,Description,FX,Change,,Balance,,Order Id
+23-12-2025,10:20,23-12-2025,,,Degiro Cash Sweep Transfer,,EUR,"3487,66",EUR,"370,03",
+28-12-2023,10:00,27-12-2023,VANGUARD S&P 500 UCITS ETF USD DIS,IE00B3XXRP09,Dividend,,USD,"1.234,56",USD,"1.234,56",
+"""
+
+
+def test_load_account_csv_european_decimal_comma(tmp_path):
+    """Degiro German/Italian/French exports use ``,`` as decimal separator."""
+    path = _write_temp_csv(tmp_path, SAMPLE_ACCOUNT_CSV_EU)
+    rows = load_account_csv(path)
+    sweep = rows[0]
+    assert sweep.change_amount == Decimal("3487.66")
+    assert sweep.balance_amount == Decimal("370.03")
+
+
+def test_load_account_csv_european_thousands_dot(tmp_path):
+    """German/French style uses ``.`` for thousands and ``,`` for decimal."""
+    path = _write_temp_csv(tmp_path, SAMPLE_ACCOUNT_CSV_EU)
+    rows = load_account_csv(path)
+    div = rows[1]
+    assert div.change_amount == Decimal("1234.56")
+    assert div.balance_amount == Decimal("1234.56")
+
+
 def test_load_account_csv_skips_empty_date_lines(tmp_path):
     content = (
         "Date,Time,Value date,Product,ISIN,Description,FX,Change,,Balance,,Order Id\n"

--- a/tests/importers/degiro/test_degiro_importer.py
+++ b/tests/importers/degiro/test_degiro_importer.py
@@ -11,10 +11,10 @@ from datetime import date
 
 import pytest
 
+from opensteuerauszug.importers.degiro._number import normalize_number
 from opensteuerauszug.importers.degiro.degiro_importer import (
     DegiroImporter,
     _TRADE_RE,
-    _normalize_number,
 )
 from tests.utils.samples import get_sample_dirs
 
@@ -125,4 +125,4 @@ def test_trade_re_matches(desc, action, qty, price, currency):
     ],
 )
 def test_normalize_number(raw, expected):
-    assert _normalize_number(raw) == expected
+    assert normalize_number(raw) == expected

--- a/tests/importers/degiro/test_degiro_portfolio_parser.py
+++ b/tests/importers/degiro/test_degiro_portfolio_parser.py
@@ -88,3 +88,23 @@ def test_load_portfolio_csv_no_closing_price_for_cash(tmp_path):
     entries = load_portfolio_csv(path)
     cash = entries[0]
     assert cash.closing_price is None
+
+
+SAMPLE_PORTFOLIO_CSV_EU = """\
+Product,Symbol/ISIN,Amount,Closing,Local value,,Value in CHF
+CASH & CASH FUND & FTX CASH (EUR),,,,EUR,"500,00","485,00"
+ADVANCED MICRO DEVICES INC,US0079031078,10,"150,00",USD,"1.500,00","1.350,00"
+"""
+
+
+def test_load_portfolio_csv_european_decimal_comma(tmp_path):
+    """Degiro German/Italian/French exports use ``,`` as decimal separator."""
+    path = _write_temp_csv(tmp_path, SAMPLE_PORTFOLIO_CSV_EU)
+    entries = load_portfolio_csv(path)
+    cash = entries[0]
+    assert cash.local_amount == Decimal("500.00")
+    assert cash.value_chf == Decimal("485.00")
+    amd = entries[1]
+    assert amd.closing_price == Decimal("150.00")
+    assert amd.local_amount == Decimal("1500.00")
+    assert amd.value_chf == Decimal("1350.00")


### PR DESCRIPTION
## Summary
Add support for parsing Degiro CSV exports that use European number formatting (decimal comma and dot thousands separators). Degiro exports use locale-specific number formatting based on the user's account language, so German/Italian/French exports use `1.234,56` while English exports use `1,234.56`.

## Changes
- **New module** `src/opensteuerauszug/importers/degiro/_number.py`:
  - `normalize_number()`: Handles multiple number format styles (Swiss/Italian apostrophe thousands, English/US comma thousands, German/French dot thousands with comma decimal, and plain European decimal comma)
  - `to_decimal_localized()`: Wrapper around the common `to_decimal()` function that normalizes European formats before parsing

- **Updated parsers** to use locale-aware number parsing:
  - `account_csv_parser.py`: Import `to_decimal_localized` instead of the common `to_decimal`
  - `portfolio_csv_parser.py`: Import `to_decimal_localized` instead of the common `to_decimal`

- **Refactored** `degiro_importer.py`:
  - Removed the local `_normalize_number()` function (now in `_number.py`)
  - Import `normalize_number` from the new module for any remaining uses

- **Added test coverage**:
  - `test_load_account_csv_european_decimal_comma()`: Verifies parsing of account CSV with European decimal comma
  - `test_load_account_csv_european_thousands_dot()`: Verifies parsing of German/French style thousands separator
  - `test_load_portfolio_csv_european_decimal_comma()`: Verifies parsing of portfolio CSV with European number formats

## Implementation Details
The `normalize_number()` function intelligently detects the number format by checking the positions of commas and dots:
- If both exist, the rightmost separator determines the decimal point
- If only comma exists, it's treated as decimal separator
- Apostrophes are stripped as thousands separators

https://claude.ai/code/session_019NPFbvmq3kiDL1vuYpwNrM