### PR TITLE
Standalone single-file web app: run the full pipeline in the browser

### DIFF
--- a/.github/workflows/web-app.yml
+++ b/.github/workflows/web-app.yml
@@ -1,0 +1,41 @@
+# Builds the standalone single-file web app (Pyodide based) and uploads it
+# as a workflow artifact. See docs/webapp.md.
+
+name: Web app
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    paths:
+      - "web/**"
+      - "scripts/build_web_app.py"
+      - "src/opensteuerauszug/util/web_runner.py"
+      - "pyproject.toml"
+      - ".github/workflows/web-app.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Build single-file web app
+        run: python scripts/build_web_app.py --output dist/web/opensteuerauszug.html
+      - name: Smoke test in headless Chromium
+        run: |
+          npm install playwright
+          npx playwright install --with-deps chromium
+          node web/dev/e2e_smoke.mjs dist/web/opensteuerauszug.html
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: opensteuerauszug-webapp
+          path: dist/web/opensteuerauszug.html
+          if-no-files-found: error

--- a/.github/workflows/web-app.yml
+++ b/.github/workflows/web-app.yml
@@ -26,6 +26,11 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+          pip install git+https://github.com/vroonhof/pdf417-py.git
       - name: Build single-file web app
         run: python scripts/build_web_app.py --output dist/web/opensteuerauszug.html
       - name: Smoke test in headless Chromium

--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ For more information on required due diligence see the the user guide.
 
 ## Usage
 
+### Standalone web app (no installation)
+
+OpenSteuerAuszug also ships as a **single HTML file** that runs the whole
+pipeline in your browser via WebAssembly — download it, open it, and a
+wizard guides you through the steps. Your financial data never leaves your
+computer. See the [web app guide](docs/webapp.md) for where to get it and
+how it works, or build it yourself with `python scripts/build_web_app.py`.
+
 ### Main usage case: Generating Steuerauszug from Broker Data
 
 After installing, use the [User Guide](docs/user_guide.md) as the main

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -374,7 +374,7 @@ but because the author wisely decided to finish their tax return before embarkin
 * Recruit more testers fro real world data use.
 * Implement plausibility checks, in particular for tax withholding.
 * produce more automated test scenarios.
-* See if this can be deployed as a standalone web pages with WASM.
+* ~~See if this can be deployed as a standalone web pages with WASM.~~ Done — see the [web app guide](webapp.md).
 * Cleanup helper scripts and provide clean pipx executable package
 
 

--- a/docs/webapp.md
+++ b/docs/webapp.md
@@ -1,0 +1,99 @@
+# Standalone Web App
+
+OpenSteuerAuszug can run as a **single HTML file in your browser** — no
+Python installation needed. The page embeds the full processing pipeline
+(compiled to WebAssembly via [Pyodide](https://pyodide.org)) and walks you
+through generating your Steuerauszug step by step.
+
+## Privacy model
+
+Your broker statements, personal details and the generated Steuerauszug
+**never leave your computer**. The page makes exactly two kinds of network
+requests, both for public open-source code:
+
+1. The Pyodide Python runtime from the jsDelivr CDN (~15 MB, once, then
+   cached by the browser).
+2. The Python library dependencies from PyPI (cached likewise).
+
+The OpenSteuerAuszug code itself is embedded inside the HTML file. Settings
+are stored in the browser's local storage, and the (public, non-personal)
+Kursliste file is cached in IndexedDB so you only add it once per tax year.
+
+## Getting the app
+
+Download `opensteuerauszug.html` from the *Web app* workflow artifact on the
+[GitHub Actions page](https://github.com/vroonhof/opensteuerauszug/actions/workflows/web-app.yml)
+(or build it yourself, see below), save it anywhere, and open it in a modern
+browser (Chrome/Edge/Firefox; an internet connection is needed on first load
+to fetch the runtime).
+
+## Using the wizard
+
+The page guides you through six steps:
+
+1. **Welcome** — read the disclaimer; the Python engine starts loading in
+   the background (progress in the bar at the bottom).
+2. **Your details** — name, canton, tax year, document language, broker and
+   calculation level. Schwab and Fidelity additionally need your account
+   number(s). Everything is remembered on this device. Under *Advanced* you
+   can inspect or hand-edit the generated `config.toml` (see the
+   [configuration guide](config.md)).
+3. **Kursliste** — add the official ESTV Kursliste for your tax year
+   (`kursliste_YYYY.xml` from [ictax.admin.ch](https://www.ictax.admin.ch/extern/en.html#/xml),
+   or the much faster `kursliste_YYYY.sqlite` produced by
+   `opensteuerauszug kursliste download`). The file is cached in the browser.
+4. **Broker files** — add your broker export(s); the required files per
+   broker are described in the importer guides (see the
+   [user guide](user_guide.md)). Optionally attach PDFs to prepend/append.
+5. **Generate** — runs import → validate → calculate → reconcile → render
+   right in the page, with the full processing log shown live.
+6. **Download** — save the PDF Steuerauszug (and the eCH-0196 XML), review
+   the verification checklist, and import the PDF into your tax software.
+
+All the caveats of the CLI apply unchanged — **verify the generated
+statement before filing** (see the [user guide](user_guide.md)).
+
+## Limitations compared to the CLI
+
+- Processing a large Kursliste **XML** in the browser is slow (minutes) and
+  memory-hungry; prefer the SQLite form for regular use.
+- The `verify` workflow for existing statements and the Kursliste download
+  command are not exposed in the UI.
+- Very large portfolios may hit browser memory limits.
+
+## Building it yourself
+
+```bash
+python scripts/build_web_app.py            # writes dist/web/opensteuerauszug.html
+```
+
+The script builds a wheel of this repository plus the git-pinned
+dependencies (`ibflex2`, `pdf417gen`), embeds them base64-encoded into
+`web/app_template.html`, and records the PyPI dependency list which the page
+installs at load time via micropip (binary packages such as `lxml` and
+`Pillow` come prebuilt from the Pyodide distribution). Building requires
+network access to PyPI and GitHub.
+
+### Self-hosting / offline Pyodide
+
+By default the page loads Pyodide from jsDelivr. To use a self-hosted copy,
+either open the page with `?pyodide=https://your.host/pyodide/v0.29.4/full/`
+or set the base URL under *Advanced: runtime options* on the welcome step.
+
+## Development notes
+
+- The UI lives in `web/app_template.html` (plain HTML/CSS/JS, no build
+  tooling). The Python side entry point is
+  `src/opensteuerauszug/util/web_runner.py`, which is covered by the normal
+  pytest suite (`tests/util/test_web_runner.py`).
+- `web/dev/e2e_smoke.mjs` drives the whole wizard in headless Chromium
+  against a mock Pyodide runtime (`web/dev/mock_pyodide.js`):
+
+  ```bash
+  python scripts/build_web_app.py
+  npm install playwright && npx playwright install chromium
+  node web/dev/e2e_smoke.mjs dist/web/opensteuerauszug.html
+  ```
+
+- CI builds and smoke-tests the app via `.github/workflows/web-app.yml` and
+  uploads the HTML as an artifact.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -116,3 +116,16 @@ This will:
 create a check run. When you opt in to `--confirm-upload` without `--upload-artifacts`, only the
 stderr text is sent to the check run summary. Only opt in after reviewing outputs and confirming
 they are safe to publish.
+
+### Web App Builder (`scripts/build_web_app.py`)
+
+Builds the standalone single-file web app (`dist/web/opensteuerauszug.html`)
+that runs the whole pipeline in the browser via Pyodide/WebAssembly. It
+builds wheels for this repository and the git-pinned dependencies and embeds
+them into `web/app_template.html`. Requires network access (PyPI + GitHub).
+
+```bash
+python scripts/build_web_app.py
+```
+
+See [docs/webapp.md](../docs/webapp.md) for details.

--- a/scripts/build_web_app.py
+++ b/scripts/build_web_app.py
@@ -8,26 +8,40 @@ downloadable HTML file:
   * builds a wheel of this repository,
   * builds wheels for the git-pinned dependencies (ibflex2, pdf417gen)
     which are not available on PyPI,
-  * embeds those wheels (base64) plus the default security identifiers CSV
-    into ``web/app_template.html``,
-  * embeds the list of regular PyPI dependencies, which the page installs
-    at load time via micropip (binary packages such as lxml and Pillow come
-    from the Pyodide distribution).
+  * resolves the full runtime dependency closure against the *current
+    environment* (the tested venv) and downloads the exact ``name==version``
+    pure-Python wheels, so the page installs precisely the code that the
+    test suite ran against — the browser never contacts PyPI,
+  * embeds all those wheels (base64) plus the default security identifiers
+    CSV into ``web/app_template.html``.
+
+Binary packages (lxml, Pillow, pydantic-core, …) cannot be embedded; they
+come from the Pyodide distribution, whose versions are frozen by the
+``PYODIDE_VERSION`` pin in the template.  The script fetches the matching
+``pyodide-lock.json`` to decide which packages those are.
 
 Usage:
     python scripts/build_web_app.py [--output dist/web/opensteuerauszug.html]
 
-Requires network access (PyPI + GitHub) to build the wheels.
+Must run inside the project venv (it locks to the installed versions).
+Requires network access (PyPI + GitHub + Pyodide CDN).
 """
 
 import argparse
 import base64
+import importlib.metadata
 import json
+import re
 import subprocess
 import sys
 import tempfile
+import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
+
+from packaging.markers import default_environment
+from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
 
 try:
     import tomllib  # Python >= 3.11
@@ -38,10 +52,6 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 TEMPLATE_PATH = REPO_ROOT / "web" / "app_template.html"
 IDENTIFIERS_CSV = REPO_ROOT / "data" / "security_identifiers.csv"
 BUNDLE_PLACEHOLDER = "__OSA_BUNDLE_JSON__"
-
-# Dependencies that must not be sent to micropip.  ``micropip`` itself is
-# provided by Pyodide and installed separately by the page.
-_SKIP_REQUIREMENTS: set = set()
 
 
 def collect_dependencies(pyproject_path: Path) -> tuple:
@@ -56,13 +66,118 @@ def collect_dependencies(pyproject_path: Path) -> tuple:
     git_reqs = []
     for dep in project["dependencies"]:
         requirement = dep.split("#", 1)[0].strip()
-        if not requirement or requirement in _SKIP_REQUIREMENTS:
+        if not requirement:
             continue
         if "@ git+" in requirement:
             git_reqs.append(requirement)
         else:
             pypi_reqs.append(requirement)
     return pypi_reqs, git_reqs, project.get("version", "0.0.0")
+
+
+def read_pyodide_version(template_text: str) -> str:
+    """Extract the Pyodide version pinned in the page template."""
+    match = re.search(r'const PYODIDE_VERSION = "([^"]+)"', template_text)
+    if not match:
+        raise ValueError("template does not define PYODIDE_VERSION")
+    return match.group(1)
+
+
+def fetch_pyodide_distribution(version: str) -> dict:
+    """Map canonical package name -> lockfile key for the Pyodide distribution.
+
+    These packages (binary builds like lxml/Pillow among them) are served from
+    the version-pinned Pyodide CDN, so they are excluded from the embedded
+    wheel set.
+    """
+    url = f"https://cdn.jsdelivr.net/pyodide/v{version}/full/pyodide-lock.json"
+    with urllib.request.urlopen(url) as resp:
+        lock = json.load(resp)
+    return {canonicalize_name(name): name for name in lock["packages"]}
+
+
+def resolve_locked_closure(root_reqs: list, skip_names: set, pyodide_dist: dict) -> tuple:
+    """Walk the runtime dependency closure of the *installed* environment.
+
+    Returns ``(locked, dist_used)`` where ``locked`` maps canonical package
+    name to the exact installed version (to be embedded as a wheel) and
+    ``dist_used`` lists the Pyodide-distribution package names the page must
+    load at runtime.  Markers are evaluated for the build environment; the
+    browser smoke test is the safety net for emscripten-only divergence.
+    """
+    env: dict = dict(default_environment())
+    locked: dict = {}
+    dist_used: set = set()
+    queue = [Requirement(r) for r in root_reqs]
+    seen = set()
+    while queue:
+        req = queue.pop()
+        name = canonicalize_name(req.name)
+        if name in skip_names:
+            continue
+        key = (name, frozenset(req.extras))
+        if key in seen:
+            continue
+        seen.add(key)
+        if name in pyodide_dist:
+            dist_used.add(pyodide_dist[name])
+            continue  # transitive deps come from the Pyodide lockfile
+        try:
+            dist = importlib.metadata.distribution(req.name)
+        except importlib.metadata.PackageNotFoundError:
+            raise SystemExit(
+                f"'{req.name}' is not installed here — run this script inside "
+                "the project venv (pip install -e .) so versions can be locked."
+            )
+        if req.specifier and not req.specifier.contains(dist.version, prereleases=True):
+            raise SystemExit(
+                f"installed {req.name} {dist.version} does not satisfy '{req}'; "
+                "fix the venv before building."
+            )
+        locked[name] = dist.version
+        for dep_str in dist.requires or []:
+            dep = Requirement(dep_str)
+            if dep.marker is not None:
+                extras = req.extras or {""}
+                if not any(dep.marker.evaluate({**env, "extra": e}) for e in extras):
+                    continue
+            queue.append(dep)
+    return locked, sorted(dist_used)
+
+
+def download_locked_wheels(locked: dict, wheel_dir: Path) -> list:
+    """Download the exact ``name==version`` pure-Python wheels from PyPI.
+
+    Anything without a universal (``none-any``) wheel cannot run in the
+    browser unless the Pyodide distribution provides it, so that is a build
+    error rather than something to paper over.
+    """
+    wheel_dir.mkdir(parents=True, exist_ok=True)
+    before = set(wheel_dir.glob("*.whl"))
+    cmd = [
+        sys.executable,
+        "-m",
+        "pip",
+        "download",
+        "--no-deps",
+        "--only-binary",
+        ":all:",
+        "--implementation",
+        "py",
+        "--abi",
+        "none",
+        "--platform",
+        "any",
+        "--dest",
+        str(wheel_dir),
+        *[f"{name}=={version}" for name, version in sorted(locked.items())],
+    ]
+    subprocess.run(cmd, check=True)
+    wheels = sorted(set(wheel_dir.glob("*.whl")) - before) or sorted(wheel_dir.glob("*.whl"))
+    bad = [w.name for w in wheels if not w.name.endswith("-none-any.whl")]
+    if bad:
+        raise RuntimeError(f"not universal pure-Python wheels: {', '.join(bad)}")
+    return wheels
 
 
 def build_wheels(requirements: list, wheel_dir: Path) -> list:
@@ -92,7 +207,8 @@ def build_wheels(requirements: list, wheel_dir: Path) -> list:
 
 def make_bundle(
     wheel_paths: list,
-    pypi_requirements: list,
+    pyodide_packages: list,
+    lock: dict,
     version: str,
     identifiers_csv: Path = IDENTIFIERS_CSV,
 ) -> dict:
@@ -109,7 +225,10 @@ def make_bundle(
     bundle = {
         "version": version,
         "builtAt": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-        "requirements": pypi_requirements,
+        # Packages loaded from the version-pinned Pyodide distribution.
+        "pyodidePackages": pyodide_packages,
+        # Informational: the exact versions embedded as wheels.
+        "lock": {name: lock[name] for name in sorted(lock)},
         "wheels": wheels,
         "identifiersCsv": (
             base64.b64encode(identifiers_csv.read_bytes()).decode("ascii")
@@ -152,8 +271,18 @@ def main(argv=None) -> int:
     )
     args = parser.parse_args(argv)
 
+    template_text = args.template.read_text(encoding="utf-8")
+    pyodide_version = read_pyodide_version(template_text)
+    print(f"Pyodide distribution: v{pyodide_version}")
+    pyodide_dist = fetch_pyodide_distribution(pyodide_version)
+
     pypi_reqs, git_reqs, version = collect_dependencies(REPO_ROOT / "pyproject.toml")
-    print(f"PyPI requirements ({len(pypi_reqs)}): {', '.join(pypi_reqs)}")
+    skip_names = {canonicalize_name(Requirement(req).name) for req in git_reqs}
+    skip_names.add(canonicalize_name("opensteuerauszug"))
+    locked, dist_used = resolve_locked_closure(pypi_reqs, skip_names, pyodide_dist)
+    print(f"From Pyodide distribution ({len(dist_used)}): {', '.join(dist_used)}")
+    locked_desc = ", ".join(f"{n}=={v}" for n, v in sorted(locked.items()))
+    print(f"Locked PyPI wheels ({len(locked)}): {locked_desc}")
     print(f"Git requirements ({len(git_reqs)}): {', '.join(git_reqs)}")
 
     with tempfile.TemporaryDirectory() as tmp:
@@ -163,6 +292,8 @@ def main(argv=None) -> int:
         for req in git_reqs:
             print(f"Building wheel for {req}…")
             wheel_paths.extend(build_wheels([req], wheel_dir))
+        print("Downloading locked dependency wheels…")
+        wheel_paths.extend(download_locked_wheels(locked, wheel_dir))
         # De-duplicate while keeping order (pip may rebuild into same dir).
         seen = set()
         unique_wheels = []
@@ -171,8 +302,8 @@ def main(argv=None) -> int:
                 seen.add(path.name)
                 unique_wheels.append(path)
 
-        bundle = make_bundle(unique_wheels, pypi_reqs, version)
-        html = render_html(args.template.read_text(encoding="utf-8"), bundle)
+        bundle = make_bundle(unique_wheels, dist_used, locked, version)
+        html = render_html(template_text, bundle)
 
         args.output.parent.mkdir(parents=True, exist_ok=True)
         args.output.write_text(html, encoding="utf-8")

--- a/scripts/build_web_app.py
+++ b/scripts/build_web_app.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Build the standalone single-file web app (opensteuerauszug.html).
+
+The web app runs the full OpenSteuerAuszug pipeline in the browser via
+Pyodide (CPython compiled to WebAssembly).  This script produces a single,
+downloadable HTML file:
+
+  * builds a wheel of this repository,
+  * builds wheels for the git-pinned dependencies (ibflex2, pdf417gen)
+    which are not available on PyPI,
+  * embeds those wheels (base64) plus the default security identifiers CSV
+    into ``web/app_template.html``,
+  * embeds the list of regular PyPI dependencies, which the page installs
+    at load time via micropip (binary packages such as lxml and Pillow come
+    from the Pyodide distribution).
+
+Usage:
+    python scripts/build_web_app.py [--output dist/web/opensteuerauszug.html]
+
+Requires network access (PyPI + GitHub) to build the wheels.
+"""
+
+import argparse
+import base64
+import json
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+try:
+    import tomllib  # Python >= 3.11
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 fallback
+    import tomli as tomllib
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TEMPLATE_PATH = REPO_ROOT / "web" / "app_template.html"
+IDENTIFIERS_CSV = REPO_ROOT / "data" / "security_identifiers.csv"
+BUNDLE_PLACEHOLDER = "__OSA_BUNDLE_JSON__"
+
+# Dependencies that must not be sent to micropip.  ``micropip`` itself is
+# provided by Pyodide and installed separately by the page.
+_SKIP_REQUIREMENTS: set = set()
+
+
+def collect_dependencies(pyproject_path: Path) -> tuple:
+    """Split [project.dependencies] into PyPI requirements and git URLs.
+
+    Returns ``(pypi_requirements, git_requirements, project_version)``.
+    """
+    with open(pyproject_path, "rb") as fh:
+        pyproject = tomllib.load(fh)
+    project = pyproject["project"]
+    pypi_reqs = []
+    git_reqs = []
+    for dep in project["dependencies"]:
+        requirement = dep.split("#", 1)[0].strip()
+        if not requirement or requirement in _SKIP_REQUIREMENTS:
+            continue
+        if "@ git+" in requirement:
+            git_reqs.append(requirement)
+        else:
+            pypi_reqs.append(requirement)
+    return pypi_reqs, git_reqs, project.get("version", "0.0.0")
+
+
+def build_wheels(requirements: list, wheel_dir: Path) -> list:
+    """Build wheels (without dependencies) for the given requirements.
+
+    ``requirements`` may contain local directory paths or PEP 508 strings
+    (including direct git references).  Returns the built wheel paths.
+    """
+    wheel_dir.mkdir(parents=True, exist_ok=True)
+    before = set(wheel_dir.glob("*.whl"))
+    cmd = [
+        sys.executable,
+        "-m",
+        "pip",
+        "wheel",
+        "--no-deps",
+        "--wheel-dir",
+        str(wheel_dir),
+        *requirements,
+    ]
+    subprocess.run(cmd, check=True)
+    built = sorted(set(wheel_dir.glob("*.whl")) - before) or sorted(wheel_dir.glob("*.whl"))
+    if not built:
+        raise RuntimeError(f"pip wheel produced no wheels for {requirements}")
+    return built
+
+
+def make_bundle(
+    wheel_paths: list,
+    pypi_requirements: list,
+    version: str,
+    identifiers_csv: Path = IDENTIFIERS_CSV,
+) -> dict:
+    """Assemble the JSON bundle embedded into the HTML page."""
+    wheels = []
+    for path in wheel_paths:
+        data = Path(path).read_bytes()
+        wheels.append(
+            {
+                "name": Path(path).name,
+                "data": base64.b64encode(data).decode("ascii"),
+            }
+        )
+    bundle = {
+        "version": version,
+        "builtAt": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "requirements": pypi_requirements,
+        "wheels": wheels,
+        "identifiersCsv": (
+            base64.b64encode(identifiers_csv.read_bytes()).decode("ascii")
+            if identifiers_csv.is_file()
+            else ""
+        ),
+    }
+    return bundle
+
+
+def render_html(template_text: str, bundle: dict) -> str:
+    """Inject the bundle JSON into the template."""
+    if BUNDLE_PLACEHOLDER not in template_text:
+        raise ValueError(f"template does not contain the {BUNDLE_PLACEHOLDER} placeholder")
+    # "<" is escaped so the JSON can never terminate the surrounding
+    # <script> block (e.g. via "</script>" inside a string).
+    bundle_json = json.dumps(bundle, separators=(",", ":")).replace("<", "\\u003c")
+    return template_text.replace(BUNDLE_PLACEHOLDER, bundle_json, 1)
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=REPO_ROOT / "dist" / "web" / "opensteuerauszug.html",
+        help="Path of the generated single-file HTML app.",
+    )
+    parser.add_argument(
+        "--template",
+        type=Path,
+        default=TEMPLATE_PATH,
+        help="Template HTML file (default: web/app_template.html).",
+    )
+    parser.add_argument(
+        "--wheel-dir",
+        type=Path,
+        default=None,
+        help="Reuse/build wheels in this directory instead of a temp dir.",
+    )
+    args = parser.parse_args(argv)
+
+    pypi_reqs, git_reqs, version = collect_dependencies(REPO_ROOT / "pyproject.toml")
+    print(f"PyPI requirements ({len(pypi_reqs)}): {', '.join(pypi_reqs)}")
+    print(f"Git requirements ({len(git_reqs)}): {', '.join(git_reqs)}")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        wheel_dir = args.wheel_dir or Path(tmp) / "wheels"
+        print("Building application wheel…")
+        wheel_paths = build_wheels([str(REPO_ROOT)], wheel_dir)
+        for req in git_reqs:
+            print(f"Building wheel for {req}…")
+            wheel_paths.extend(build_wheels([req], wheel_dir))
+        # De-duplicate while keeping order (pip may rebuild into same dir).
+        seen = set()
+        unique_wheels = []
+        for path in wheel_paths:
+            if path.name not in seen:
+                seen.add(path.name)
+                unique_wheels.append(path)
+
+        bundle = make_bundle(unique_wheels, pypi_reqs, version)
+        html = render_html(args.template.read_text(encoding="utf-8"), bundle)
+
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(html, encoding="utf-8")
+
+    total_kib = args.output.stat().st_size / 1024
+    print(f"\nEmbedded wheels: {', '.join(w.name for w in unique_wheels)}")
+    print(f"Wrote {args.output} ({total_kib:.0f} KiB)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/web_app_smoke_test.js
+++ b/scripts/web_app_smoke_test.js
@@ -1,0 +1,108 @@
+// End-to-end smoke test for the standalone web app (dist/web/opensteuerauszug.html).
+//
+// Boots the built page in headless Chromium, waits for the Pyodide engine,
+// uploads the IBKR + Kursliste samples, runs the pipeline, and checks that a
+// PDF/XML download is produced.  It also fails if the page contacts any host
+// other than its own origin and the pinned Pyodide CDN — the wheel-embedding
+// build (scripts/build_web_app.py) exists precisely so that no PyPI request
+// happens at runtime, and so that dependencies the build machine never saw
+// (e.g. via emscripten-only markers) cannot sneak in unnoticed.
+//
+// Usage:  npm install playwright && npx playwright install chromium
+//         python scripts/build_web_app.py
+//         node scripts/web_app_smoke_test.js
+const http = require("http");
+const fs = require("fs");
+const path = require("path");
+const { chromium } = require("playwright");
+
+const REPO = path.dirname(__dirname);
+const HTML = REPO + "/dist/web/opensteuerauszug.html";
+
+async function poll(page, deadline, fn, what) {
+  let last = "";
+  while (Date.now() < deadline) {
+    const r = await fn();
+    if (r.log && r.log !== last) { console.log(r.log); last = r.log; }
+    if (r.done) return r;
+    await new Promise((s) => setTimeout(s, 2000));
+  }
+  throw new Error("timed out waiting for " + what);
+}
+
+(async () => {
+  const server = http.createServer((req, res) => {
+    res.setHeader("Content-Type", "text/html");
+    fs.createReadStream(HTML).pipe(res);
+  }).listen(0);
+  await new Promise((r) => server.once("listening", r));
+  const url = `http://127.0.0.1:${server.address().port}/`;
+
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  page.on("console", (m) => {
+    if (m.type() === "error") console.log("[console.error]", m.text().slice(0, 300));
+  });
+  const badHosts = new Set();
+  page.on("request", (r) => {
+    const u = new URL(r.url());
+    if (!u.protocol.startsWith("http")) return; // blob:/data: are page-internal
+    if (u.host !== new URL(url).host && u.host !== "cdn.jsdelivr.net") badHosts.add(u.host);
+  });
+  await page.goto(url);
+
+  // 1. Wait for the Python engine.
+  await poll(page, Date.now() + 8 * 60 * 1000, async () => {
+    const s = await page.evaluate(() => {
+      const t = (id) => (document.getElementById(id) || {}).textContent || "";
+      const c = (id) => (document.getElementById(id) || {}).className || "";
+      return { pill: c("enginePill"), detail: t("engineDetail"), err: t("engineErrorBox") };
+    });
+    if (s.pill.includes("error")) throw new Error("engine error: " + s.detail + "\n" + s.err);
+    return { done: s.pill.includes("ready"), log: s.detail };
+  }, "engine ready");
+  console.log("engine ready");
+
+  // 2. Upload samples and go to the Generate step.
+  await page.setInputFiles("#fileKursliste", [REPO + "/tests/samples/kursliste/kursliste_mini_2025.xml"]);
+  await page.setInputFiles("#fileBroker", [REPO + "/tests/samples/import/ibkr/vtandchill_2025.xml"]);
+  await page.evaluate(() => go(4));
+
+  // 3. Run.
+  await poll(page, Date.now() + 60 * 1000, async () => {
+    const s = await page.evaluate(() => ({
+      disabled: document.getElementById("btnRun").disabled,
+      blockers: document.getElementById("runBlockers").textContent,
+    }));
+    return { done: !s.disabled, log: s.disabled ? "run blocked: " + s.blockers.replace(/\s+/g, " ").slice(0, 200) : "" };
+  }, "run button enabled");
+  await page.click("#btnRun");
+  console.log("run started");
+
+  const res = await poll(page, Date.now() + 6 * 60 * 1000, async () => {
+    const s = await page.evaluate(() => ({
+      running: document.getElementById("runStatus").style.display !== "none",
+      log: document.getElementById("runLog").textContent,
+      downloads: Array.from(document.querySelectorAll("#downloads a")).map((a) => a.textContent.trim()),
+    }));
+    const lines = s.log.trim().split("\n");
+    return { done: !s.running && s.log.length > 0, log: lines[lines.length - 1], s };
+  }, "pipeline run");
+
+  const log = res.s.log;
+  const ok = log.includes("Processing finished successfully.") && res.s.downloads.length > 0;
+  console.log("downloads offered:", JSON.stringify(res.s.downloads));
+  if (!ok) {
+    console.log("--- last 40 log lines ---");
+    console.log(log.trim().split("\n").slice(-40).join("\n"));
+    console.log("SMOKE TEST FAILED");
+    await browser.close(); server.close(); process.exit(1);
+  }
+  if (badHosts.size) {
+    console.log("SMOKE TEST FAILED: unexpected network hosts contacted:", [...badHosts].join(", "));
+    await browser.close(); server.close(); process.exit(1);
+  }
+  console.log("network check passed: only the page origin and cdn.jsdelivr.net were contacted");
+  console.log("SMOKE TEST PASSED: pipeline ran in-browser and produced downloads");
+  await browser.close(); server.close(); process.exit(0);
+})().catch((e) => { console.log("SMOKE TEST FAILED:", e.message); process.exit(1); });

--- a/src/opensteuerauszug/util/web_runner.py
+++ b/src/opensteuerauszug/util/web_runner.py
@@ -24,10 +24,14 @@ class _CallbackWriter:
         self._buffer = ""
 
     def write(self, text: str) -> int:
-        self._buffer += text
+        # Treat carriage returns as line breaks so in-place progress tickers
+        # (e.g. the Kursliste converter's "\rProcessed N records...") reach
+        # the callback while they happen instead of piling up in the buffer.
+        self._buffer += text.replace("\r", "\n")
         while "\n" in self._buffer:
             line, self._buffer = self._buffer.split("\n", 1)
-            self._callback(line)
+            if line:
+                self._callback(line)
         return len(text)
 
     def flush(self) -> None:
@@ -149,6 +153,68 @@ def run_cli(args: List[str], on_output: Optional[OutputCallback] = None) -> dict
         sys.stderr = old_stderr
         _reset_root_logging()
     return {"exit_code": exit_code}
+
+
+def convert_kursliste_xmls(kursliste_dir: str, on_output: Optional[OutputCallback] = None) -> dict:
+    """Convert Kursliste XML files in a directory to SQLite databases in place.
+
+    Loading a full Kursliste XML needs roughly 30x the file size in memory,
+    which does not fit in the browser's WebAssembly heap for real files.  The
+    streaming XML-to-SQLite converter runs in near-constant memory, so the web
+    worker calls this before the pipeline and the page caches the resulting
+    database for later runs.
+
+    Each successfully converted XML file is deleted so the pipeline picks up
+    the SQLite database instead.  XML files whose year already has a SQLite
+    database are left untouched and reported as skipped.  Returns
+    ``{"converted": [{"source", "path", "year", "size"}], "skipped": [...],
+    "errors": [{"source", "error"}]}``.
+    """
+    from opensteuerauszug.core.kursliste_manager import KurslisteManager
+    from opensteuerauszug.kursliste.converter import convert_kursliste_xml_to_sqlite
+
+    callback: OutputCallback = on_output or (lambda line: None)
+    writer = _CallbackWriter(callback)
+    manager = KurslisteManager()
+    directory = Path(kursliste_dir)
+    result: dict = {"converted": [], "skipped": [], "errors": []}
+
+    for xml_path in sorted(directory.glob("*.xml")):
+        year = manager._get_year_from_filename(xml_path.name)
+        if year is None:
+            year = manager._get_year_from_xml_content(xml_path)
+        db_path = directory / (f"kursliste_{year}.sqlite" if year else xml_path.stem + ".sqlite")
+        if db_path.is_file():
+            callback(f"Skipping {xml_path.name}: {db_path.name} already exists.")
+            result["skipped"].append(xml_path.name)
+            continue
+
+        old_stdout, old_stderr = sys.stdout, sys.stderr
+        sys.stdout = writer  # type: ignore[assignment]
+        sys.stderr = writer  # type: ignore[assignment]
+        try:
+            convert_kursliste_xml_to_sqlite(xml_path, db_path)
+        except Exception as exc:
+            db_path.unlink(missing_ok=True)
+            result["errors"].append({"source": xml_path.name, "error": str(exc)})
+        else:
+            xml_path.unlink()
+            result["converted"].append(
+                {
+                    "source": xml_path.name,
+                    "path": str(db_path),
+                    "year": year,
+                    "size": db_path.stat().st_size,
+                }
+            )
+        finally:
+            writer.flush()
+            sys.stdout = old_stdout
+            sys.stderr = old_stderr
+
+    for err in result["errors"]:
+        callback(f"Error converting {err['source']}: {err['error']}")
+    return result
 
 
 def run_process(

--- a/src/opensteuerauszug/util/web_runner.py
+++ b/src/opensteuerauszug/util/web_runner.py
@@ -13,8 +13,6 @@ import traceback
 from pathlib import Path
 from typing import Callable, List, Optional
 
-import click
-
 OutputCallback = Callable[[str], None]
 
 
@@ -129,17 +127,18 @@ def run_cli(args: List[str], on_output: Optional[OutputCallback] = None) -> dict
     _reset_root_logging()
     exit_code = 0
     try:
+        # Standalone mode makes click (or, for typer >= 0.26, its vendored
+        # copy in typer._click) print CLI errors to our redirected stderr and
+        # signal the exit code via SystemExit — so we never have to touch
+        # click's exception classes, which differ across typer versions.
         command = get_command(app)
-        result = command.main(args=args, prog_name="opensteuerauszug", standalone_mode=False)
-        if isinstance(result, int):
-            exit_code = result
-    except click.exceptions.Exit as exc:
-        exit_code = exc.exit_code
-    except SystemExit as exc:  # pragma: no cover - defensive
-        exit_code = int(exc.code or 0)
-    except click.ClickException as exc:
-        callback(f"Error: {exc.format_message()}")
-        exit_code = exc.exit_code
+        command.main(args=args, prog_name="opensteuerauszug")
+    except SystemExit as exc:
+        if isinstance(exc.code, int):
+            exit_code = exc.code
+        elif exc.code is not None:
+            callback(str(exc.code))
+            exit_code = 1
     except Exception:
         for line in traceback.format_exc(limit=20).splitlines():
             callback(line)

--- a/src/opensteuerauszug/util/web_runner.py
+++ b/src/opensteuerauszug/util/web_runner.py
@@ -1,0 +1,194 @@
+"""Helpers to drive the processing pipeline from a web (Pyodide/WASM) frontend.
+
+The standalone web app (see ``web/`` and ``scripts/build_web_app.py``) runs the
+regular CLI pipeline inside the browser.  This module provides a small, plain
+Python API on top of the Typer CLI so the JavaScript side only has to deal
+with file paths and simple dictionaries.  It is intentionally free of any
+Pyodide specific imports so it can be tested natively with pytest.
+"""
+
+import logging
+import sys
+import traceback
+from pathlib import Path
+from typing import Callable, List, Optional
+
+import click
+
+OutputCallback = Callable[[str], None]
+
+
+class _CallbackWriter:
+    """A minimal text stream that forwards complete lines to a callback."""
+
+    def __init__(self, callback: OutputCallback):
+        self._callback = callback
+        self._buffer = ""
+
+    def write(self, text: str) -> int:
+        self._buffer += text
+        while "\n" in self._buffer:
+            line, self._buffer = self._buffer.split("\n", 1)
+            self._callback(line)
+        return len(text)
+
+    def flush(self) -> None:
+        if self._buffer:
+            self._callback(self._buffer)
+            self._buffer = ""
+
+    def isatty(self) -> bool:
+        return False
+
+
+def ensure_workspace(root: str = "/work") -> dict:
+    """Create the standard workspace layout used by the web UI.
+
+    Returns a dictionary with the created paths so the JavaScript side can
+    write uploaded files into the right places.
+    """
+    base = Path(root)
+    layout = {
+        "root": base,
+        "input": base / "input",
+        "kursliste": base / "kursliste",
+        "output": base / "output",
+        "config": base / "config",
+    }
+    for path in layout.values():
+        path.mkdir(parents=True, exist_ok=True)
+    return {name: str(path) for name, path in layout.items()}
+
+
+def _reset_root_logging() -> None:
+    """Drop root handlers so ``logging.basicConfig`` in the CLI re-attaches
+    to the *current* ``sys.stderr`` (which we redirect per run)."""
+    root = logging.getLogger()
+    for handler in list(root.handlers):
+        root.removeHandler(handler)
+
+
+def build_cli_args(
+    input_path: str,
+    output_pdf: str,
+    importer: str,
+    tax_year: int,
+    kursliste_dir: str,
+    config_path: Optional[str] = None,
+    xml_output: Optional[str] = None,
+    identifiers_csv: Optional[str] = None,
+    tax_calculation_level: str = "kursliste",
+    log_level: str = "INFO",
+    extra_args: Optional[List[str]] = None,
+) -> List[str]:
+    """Translate web UI options into CLI arguments for the ``process`` command."""
+    args = [
+        "process",
+        input_path,
+        "--importer",
+        importer,
+        "--tax-year",
+        str(tax_year),
+        "--kursliste-dir",
+        kursliste_dir,
+        "--output",
+        output_pdf,
+        "--tax-calculation-level",
+        tax_calculation_level,
+        "--log-level",
+        log_level,
+    ]
+    if config_path:
+        args.extend(["--config", config_path])
+    if xml_output:
+        args.extend(["--xml-output", xml_output])
+    if identifiers_csv:
+        args.extend(["--identifiers-csv-path", identifiers_csv])
+    if extra_args:
+        args.extend(extra_args)
+    return args
+
+
+def run_cli(args: List[str], on_output: Optional[OutputCallback] = None) -> dict:
+    """Run the opensteuerauszug CLI with the given arguments.
+
+    stdout/stderr (and log output) produced during the run are forwarded
+    line by line to ``on_output``.  Returns ``{"exit_code": int}``; the run
+    never raises so the JavaScript caller only needs to check the code.
+    """
+    # Imported lazily so that merely importing this module stays cheap.
+    from typer.main import get_command
+
+    from opensteuerauszug.steuerauszug import app
+
+    callback: OutputCallback = on_output or (lambda line: None)
+    writer = _CallbackWriter(callback)
+    old_stdout, old_stderr = sys.stdout, sys.stderr
+    sys.stdout = writer  # type: ignore[assignment]
+    sys.stderr = writer  # type: ignore[assignment]
+    _reset_root_logging()
+    exit_code = 0
+    try:
+        command = get_command(app)
+        result = command.main(args=args, prog_name="opensteuerauszug", standalone_mode=False)
+        if isinstance(result, int):
+            exit_code = result
+    except click.exceptions.Exit as exc:
+        exit_code = exc.exit_code
+    except SystemExit as exc:  # pragma: no cover - defensive
+        exit_code = int(exc.code or 0)
+    except click.ClickException as exc:
+        callback(f"Error: {exc.format_message()}")
+        exit_code = exc.exit_code
+    except Exception:
+        for line in traceback.format_exc(limit=20).splitlines():
+            callback(line)
+        exit_code = 1
+    finally:
+        writer.flush()
+        sys.stdout = old_stdout
+        sys.stderr = old_stderr
+        _reset_root_logging()
+    return {"exit_code": exit_code}
+
+
+def run_process(
+    input_path: str,
+    output_pdf: str,
+    importer: str,
+    tax_year: int,
+    kursliste_dir: str,
+    config_path: Optional[str] = None,
+    xml_output: Optional[str] = None,
+    identifiers_csv: Optional[str] = None,
+    tax_calculation_level: str = "kursliste",
+    log_level: str = "INFO",
+    extra_args: Optional[List[str]] = None,
+    on_output: Optional[OutputCallback] = None,
+) -> dict:
+    """High level entry point used by the web worker.
+
+    Runs the full pipeline and reports which of the requested output files
+    were actually produced.
+    """
+    args = build_cli_args(
+        input_path=input_path,
+        output_pdf=output_pdf,
+        importer=importer,
+        tax_year=tax_year,
+        kursliste_dir=kursliste_dir,
+        config_path=config_path,
+        xml_output=xml_output,
+        identifiers_csv=identifiers_csv,
+        tax_calculation_level=tax_calculation_level,
+        log_level=log_level,
+        extra_args=extra_args,
+    )
+    result = run_cli(args, on_output=on_output)
+    outputs = {}
+    for name, path_str in (("pdf", output_pdf), ("xml", xml_output)):
+        if path_str and Path(path_str).is_file():
+            outputs[name] = path_str
+    result["outputs"] = outputs
+    result["success"] = result["exit_code"] == 0 and "pdf" in outputs
+    return result

--- a/tests/scripts/test_build_web_app.py
+++ b/tests/scripts/test_build_web_app.py
@@ -1,0 +1,78 @@
+import base64
+import importlib.util
+import json
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+@pytest.fixture(scope="module")
+def build_web_app():
+    spec = importlib.util.spec_from_file_location(
+        "build_web_app", PROJECT_ROOT / "scripts" / "build_web_app.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules["build_web_app"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_dummy_wheel(path: Path) -> Path:
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr("dummy/__init__.py", "")
+    return path
+
+
+def test_dependencies_are_split_into_pypi_and_git(build_web_app):
+    pypi, git, version = build_web_app.collect_dependencies(PROJECT_ROOT / "pyproject.toml")
+    assert version
+    assert any(req.startswith("pydantic") for req in pypi)
+    assert any(req.startswith("reportlab") for req in pypi)
+    assert all("git+" not in req for req in pypi)
+    joined = " ".join(git)
+    assert "ibflex2" in joined and "pdf417gen" in joined
+    # Inline TOML comments must not leak into requirement strings.
+    assert all("#" not in req for req in pypi)
+
+
+def test_bundle_embeds_wheels_and_identifiers(build_web_app, tmp_path):
+    wheel = _make_dummy_wheel(tmp_path / "dummy-1.0-py3-none-any.whl")
+    csv = tmp_path / "ids.csv"
+    csv.write_text("isin,valor\n")
+    bundle = build_web_app.make_bundle([wheel], ["pydantic>=2"], "1.2.3", identifiers_csv=csv)
+    assert bundle["version"] == "1.2.3"
+    assert bundle["requirements"] == ["pydantic>=2"]
+    assert bundle["wheels"][0]["name"] == "dummy-1.0-py3-none-any.whl"
+    assert base64.b64decode(bundle["wheels"][0]["data"]) == wheel.read_bytes()
+    assert base64.b64decode(bundle["identifiersCsv"]) == b"isin,valor\n"
+
+
+def test_rendered_html_contains_parseable_bundle_json(build_web_app, tmp_path):
+    template = (PROJECT_ROOT / "web" / "app_template.html").read_text(encoding="utf-8")
+    wheel = _make_dummy_wheel(tmp_path / "dummy-1.0-py3-none-any.whl")
+    bundle = build_web_app.make_bundle(
+        [wheel], ["pydantic>=2"], "1.2.3", identifiers_csv=tmp_path / "missing.csv"
+    )
+    # A hostile-looking string must not be able to close the <script> tag.
+    bundle["requirements"].append("evil</script><script>")
+    html = build_web_app.render_html(template, bundle)
+    assert build_web_app.BUNDLE_PLACEHOLDER not in html
+    assert "</script><script>alert" not in html
+    start = html.index('<script type="application/json" id="osa-bundle">') + len(
+        '<script type="application/json" id="osa-bundle">'
+    )
+    end = html.index("</script>", start)
+    parsed = json.loads(html[start:end])
+    assert parsed["version"] == "1.2.3"
+    assert parsed["wheels"][0]["name"] == "dummy-1.0-py3-none-any.whl"
+    assert "</script>" not in html[start:end]
+
+
+def test_render_html_rejects_template_without_placeholder(build_web_app):
+    with pytest.raises(ValueError):
+        build_web_app.render_html("<html></html>", {"version": "1"})

--- a/tests/scripts/test_build_web_app.py
+++ b/tests/scripts/test_build_web_app.py
@@ -44,22 +44,46 @@ def test_bundle_embeds_wheels_and_identifiers(build_web_app, tmp_path):
     wheel = _make_dummy_wheel(tmp_path / "dummy-1.0-py3-none-any.whl")
     csv = tmp_path / "ids.csv"
     csv.write_text("isin,valor\n")
-    bundle = build_web_app.make_bundle([wheel], ["pydantic>=2"], "1.2.3", identifiers_csv=csv)
+    bundle = build_web_app.make_bundle(
+        [wheel], ["pydantic"], {"typer": "0.24.2"}, "1.2.3", identifiers_csv=csv
+    )
     assert bundle["version"] == "1.2.3"
-    assert bundle["requirements"] == ["pydantic>=2"]
+    assert bundle["pyodidePackages"] == ["pydantic"]
+    assert bundle["lock"] == {"typer": "0.24.2"}
     assert bundle["wheels"][0]["name"] == "dummy-1.0-py3-none-any.whl"
     assert base64.b64decode(bundle["wheels"][0]["data"]) == wheel.read_bytes()
     assert base64.b64decode(bundle["identifiersCsv"]) == b"isin,valor\n"
+
+
+def test_locked_closure_splits_dist_and_embedded_packages(build_web_app):
+    pypi, git, _ = build_web_app.collect_dependencies(PROJECT_ROOT / "pyproject.toml")
+    from packaging.requirements import Requirement
+    from packaging.utils import canonicalize_name
+
+    skip = {canonicalize_name(Requirement(req).name) for req in git}
+    skip.add(canonicalize_name("opensteuerauszug"))
+    # Pretend the Pyodide distribution ships the binary packages (as the real
+    # lockfile does) so the walk routes them there instead of embedding.
+    dist = {name: name for name in ("lxml", "pillow", "pydantic", "click", "rich")}
+    locked, dist_used = build_web_app.resolve_locked_closure(pypi, skip, dist)
+    assert "lxml" in dist_used and "pydantic" in dist_used
+    # Direct deps and transitive deps of embedded wheels get exact pins…
+    import typer
+
+    assert locked["typer"] == typer.__version__
+    assert "reportlab" in locked and "shellingham" in locked
+    # …and nothing routed to the distribution is also embedded.
+    assert not set(locked) & set(dist_used)
 
 
 def test_rendered_html_contains_parseable_bundle_json(build_web_app, tmp_path):
     template = (PROJECT_ROOT / "web" / "app_template.html").read_text(encoding="utf-8")
     wheel = _make_dummy_wheel(tmp_path / "dummy-1.0-py3-none-any.whl")
     bundle = build_web_app.make_bundle(
-        [wheel], ["pydantic>=2"], "1.2.3", identifiers_csv=tmp_path / "missing.csv"
+        [wheel], ["pydantic"], {}, "1.2.3", identifiers_csv=tmp_path / "missing.csv"
     )
     # A hostile-looking string must not be able to close the <script> tag.
-    bundle["requirements"].append("evil</script><script>")
+    bundle["pyodidePackages"].append("evil</script><script>")
     html = build_web_app.render_html(template, bundle)
     assert build_web_app.BUNDLE_PLACEHOLDER not in html
     assert "</script><script>alert" not in html

--- a/tests/util/test_web_runner.py
+++ b/tests/util/test_web_runner.py
@@ -1,5 +1,7 @@
+import shutil
 from pathlib import Path
 
+from opensteuerauszug.core.kursliste_db_reader import KurslisteDBReader
 from opensteuerauszug.util import web_runner
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
@@ -36,6 +38,95 @@ def test_run_process_generates_pdf_and_xml_from_ibkr_sample(tmp_path: Path):
     assert output_pdf.stat().st_size > 0
     assert "IBKR import complete." in log
     assert "Processing finished successfully." in log
+
+
+def test_convert_kursliste_xmls_produces_usable_sqlite(tmp_path: Path):
+    """The web worker converts uploaded Kursliste XMLs to SQLite before the
+    pipeline runs (a real XML cannot be parsed whole in the browser)."""
+    kursliste_dir = tmp_path / "kursliste"
+    kursliste_dir.mkdir()
+    # Filename without a year: the year must be read from the XML content.
+    shutil.copy(
+        PROJECT_ROOT / "tests" / "samples" / "kursliste" / "kursliste_mini.xml",
+        kursliste_dir / "kursliste_mini.xml",
+    )
+
+    lines: list[str] = []
+    result = web_runner.convert_kursliste_xmls(str(kursliste_dir), on_output=lines.append)
+
+    db_path = kursliste_dir / "kursliste_2024.sqlite"
+    assert result["errors"] == []
+    assert result["skipped"] == []
+    assert [c["source"] for c in result["converted"]] == ["kursliste_mini.xml"]
+    assert result["converted"][0] == {
+        "source": "kursliste_mini.xml",
+        "path": str(db_path),
+        "year": 2024,
+        "size": db_path.stat().st_size,
+    }
+    assert not (kursliste_dir / "kursliste_mini.xml").exists()
+    assert any("Conversion complete" in line for line in lines)
+
+    with KurslisteDBReader(str(db_path)) as reader:
+        security = reader.find_security_by_isin("US9229087690", 2024)
+    assert security is not None
+    assert security.valorNumber == 1246192
+
+
+def test_convert_kursliste_xmls_skips_year_with_existing_sqlite(tmp_path: Path):
+    kursliste_dir = tmp_path / "kursliste"
+    kursliste_dir.mkdir()
+    xml_path = kursliste_dir / "kursliste_2024.xml"
+    shutil.copy(PROJECT_ROOT / "tests" / "samples" / "kursliste" / "kursliste_mini.xml", xml_path)
+    (kursliste_dir / "kursliste_2024.sqlite").write_bytes(b"existing")
+
+    result = web_runner.convert_kursliste_xmls(str(kursliste_dir))
+
+    assert result["converted"] == []
+    assert result["skipped"] == ["kursliste_2024.xml"]
+    assert xml_path.exists()
+    assert (kursliste_dir / "kursliste_2024.sqlite").read_bytes() == b"existing"
+
+
+def test_convert_kursliste_xmls_reports_invalid_xml(tmp_path: Path):
+    kursliste_dir = tmp_path / "kursliste"
+    kursliste_dir.mkdir()
+    bad = kursliste_dir / "kursliste_2024.xml"
+    bad.write_text("<kursliste year='2024'><unclosed></kursliste>")
+
+    lines: list[str] = []
+    result = web_runner.convert_kursliste_xmls(str(kursliste_dir), on_output=lines.append)
+
+    assert result["converted"] == []
+    assert [e["source"] for e in result["errors"]] == ["kursliste_2024.xml"]
+    assert bad.exists()  # the input is left in place on failure
+    assert not (kursliste_dir / "kursliste_2024.sqlite").exists()
+    assert any("Error converting kursliste_2024.xml" in line for line in lines)
+
+
+def test_run_process_succeeds_with_converted_kursliste(tmp_path: Path):
+    """End to end: convert the XML like the worker does, then run the pipeline
+    against the resulting SQLite-only directory."""
+    kursliste_dir = tmp_path / "kursliste"
+    kursliste_dir.mkdir()
+    shutil.copy(
+        PROJECT_ROOT / "tests" / "samples" / "kursliste" / "kursliste_mini_2025.xml",
+        kursliste_dir / "kursliste_mini_2025.xml",
+    )
+    conversion = web_runner.convert_kursliste_xmls(str(kursliste_dir))
+    assert conversion["errors"] == []
+
+    result = web_runner.run_process(
+        input_path=str(
+            PROJECT_ROOT / "tests" / "samples" / "import" / "ibkr" / "vtandchill_2025.xml"
+        ),
+        output_pdf=str(tmp_path / "out.pdf"),
+        importer="ibkr",
+        tax_year=2025,
+        kursliste_dir=str(kursliste_dir),
+        on_output=lambda line: None,
+    )
+    assert result["success"] is True
 
 
 def test_run_process_reports_failure_without_kursliste(tmp_path: Path):

--- a/tests/util/test_web_runner.py
+++ b/tests/util/test_web_runner.py
@@ -1,0 +1,79 @@
+from pathlib import Path
+
+from opensteuerauszug.util import web_runner
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def test_workspace_layout_is_created(tmp_path: Path):
+    layout = web_runner.ensure_workspace(str(tmp_path / "work"))
+    assert set(layout) == {"root", "input", "kursliste", "output", "config"}
+    for path in layout.values():
+        assert Path(path).is_dir()
+
+
+def test_run_process_generates_pdf_and_xml_from_ibkr_sample(tmp_path: Path):
+    input_file = PROJECT_ROOT / "tests" / "samples" / "import" / "ibkr" / "vtandchill_2025.xml"
+    kursliste_dir = PROJECT_ROOT / "tests" / "samples" / "kursliste"
+    output_pdf = tmp_path / "out.pdf"
+    output_xml = tmp_path / "out.xml"
+
+    lines: list[str] = []
+    result = web_runner.run_process(
+        input_path=str(input_file),
+        output_pdf=str(output_pdf),
+        importer="ibkr",
+        tax_year=2025,
+        kursliste_dir=str(kursliste_dir),
+        xml_output=str(output_xml),
+        on_output=lines.append,
+    )
+
+    log = "\n".join(lines)
+    assert result["exit_code"] == 0, f"pipeline failed:\n{log}"
+    assert result["success"] is True
+    assert result["outputs"] == {"pdf": str(output_pdf), "xml": str(output_xml)}
+    assert output_pdf.stat().st_size > 0
+    assert "IBKR import complete." in log
+    assert "Processing finished successfully." in log
+
+
+def test_run_process_reports_failure_without_kursliste(tmp_path: Path):
+    input_file = PROJECT_ROOT / "tests" / "samples" / "import" / "ibkr" / "vtandchill_2025.xml"
+    empty_kursliste = tmp_path / "kursliste"
+    empty_kursliste.mkdir()
+
+    lines: list[str] = []
+    result = web_runner.run_process(
+        input_path=str(input_file),
+        output_pdf=str(tmp_path / "out.pdf"),
+        importer="ibkr",
+        tax_year=2025,
+        kursliste_dir=str(empty_kursliste),
+        on_output=lines.append,
+    )
+
+    assert result["exit_code"] != 0
+    assert result["success"] is False
+    assert "Kursliste data for tax year 2025 not found" in "\n".join(lines)
+
+
+def test_run_process_can_run_consecutively_without_duplicating_log_lines(tmp_path: Path):
+    """Log handlers must be re-created per run, otherwise the second run in the
+    same interpreter (the normal case in the browser) doubles every log line
+    or writes to a stale stream."""
+    input_file = PROJECT_ROOT / "tests" / "samples" / "import" / "ibkr" / "vtandchill_2025.xml"
+    kursliste_dir = PROJECT_ROOT / "tests" / "samples" / "kursliste"
+
+    for attempt in range(2):
+        lines: list[str] = []
+        result = web_runner.run_process(
+            input_path=str(input_file),
+            output_pdf=str(tmp_path / f"out_{attempt}.pdf"),
+            importer="ibkr",
+            tax_year=2025,
+            kursliste_dir=str(kursliste_dir),
+            on_output=lines.append,
+        )
+        assert result["exit_code"] == 0
+        assert sum("Processing finished successfully." in line for line in lines) == 1

--- a/web/app_template.html
+++ b/web/app_template.html
@@ -1,0 +1,1056 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>OpenSteuerAuszug — Swiss tax statement generator</title>
+<style>
+  :root {
+    --bg: #f5f6f8; --panel: #ffffff; --text: #1c2733; --muted: #5c6b7a;
+    --accent: #b3261e; --accent-soft: #fbeae9; --ok: #1e7f4f; --ok-soft: #e5f4ec;
+    --warn: #9a6700; --warn-soft: #fff3d6; --err: #b3261e; --err-soft: #fbeae9;
+    --border: #d8dee5; --code-bg: #10161d; --code-text: #d7e2ec;
+    --step-idle: #c3ccd6;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #10161d; --panel: #1a222c; --text: #e4ebf2; --muted: #93a3b3;
+      --accent: #ff8a80; --accent-soft: #3a2422; --ok: #5fd39a; --ok-soft: #17342a;
+      --warn: #e8b93f; --warn-soft: #3a311f; --err: #ff8a80; --err-soft: #3a2422;
+      --border: #2c3947; --code-bg: #0b1016; --code-text: #cfdae4; --step-idle: #3b4a59;
+    }
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: var(--bg); color: var(--text);
+    font: 15px/1.55 system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  }
+  header.app {
+    padding: 22px 24px 14px; max-width: 900px; margin: 0 auto;
+  }
+  header.app h1 { margin: 0 0 2px; font-size: 22px; }
+  header.app h1 .flag { font-size: 18px; }
+  header.app p { margin: 0; color: var(--muted); font-size: 14px; }
+  main { max-width: 900px; margin: 0 auto; padding: 0 24px 96px; }
+
+  /* Stepper */
+  ol.stepper {
+    list-style: none; display: flex; gap: 4px; padding: 0; margin: 18px 0 20px;
+    flex-wrap: wrap;
+  }
+  ol.stepper li {
+    display: flex; align-items: center; gap: 7px; padding: 6px 12px;
+    border-radius: 999px; font-size: 13px; color: var(--muted);
+    border: 1px solid transparent; cursor: default; user-select: none;
+  }
+  ol.stepper li .dot {
+    width: 20px; height: 20px; border-radius: 50%; background: var(--step-idle);
+    color: #fff; display: inline-flex; align-items: center; justify-content: center;
+    font-size: 11px; font-weight: 700; flex: none;
+  }
+  ol.stepper li.done .dot { background: var(--ok); }
+  ol.stepper li.active { color: var(--text); border-color: var(--border); background: var(--panel); }
+  ol.stepper li.active .dot { background: var(--accent); }
+  ol.stepper li.clickable { cursor: pointer; }
+
+  section.step { display: none; }
+  section.step.active { display: block; }
+  .card {
+    background: var(--panel); border: 1px solid var(--border); border-radius: 12px;
+    padding: 20px 22px; margin-bottom: 16px;
+  }
+  .card h2 { margin: 0 0 6px; font-size: 17px; }
+  .card p.lead { margin: 0 0 14px; color: var(--muted); font-size: 14px; }
+  .notice { border-left: 4px solid var(--warn); background: var(--warn-soft); color: var(--text);
+    padding: 10px 14px; border-radius: 0 8px 8px 0; font-size: 13.5px; margin: 12px 0; }
+  .notice.error { border-left-color: var(--err); background: var(--err-soft); }
+  .notice.ok { border-left-color: var(--ok); background: var(--ok-soft); }
+  .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(230px, 1fr)); gap: 14px; }
+  label.field { display: block; font-size: 13px; color: var(--muted); }
+  label.field b { display: block; color: var(--text); font-weight: 600; margin-bottom: 4px; font-size: 13.5px; }
+  input[type=text], input[type=number], select, textarea {
+    width: 100%; padding: 8px 10px; border: 1px solid var(--border); border-radius: 8px;
+    background: var(--bg); color: var(--text); font: inherit;
+  }
+  textarea.toml { font: 12.5px/1.5 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; min-height: 200px; }
+  input:focus, select:focus, textarea:focus { outline: 2px solid var(--accent); outline-offset: 0; border-color: transparent; }
+  .row { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; }
+  .checkbox { display: flex; gap: 8px; align-items: flex-start; font-size: 14px; margin: 8px 0; }
+  .checkbox input { margin-top: 3px; }
+
+  button {
+    font: inherit; font-weight: 600; border-radius: 9px; border: 1px solid var(--border);
+    background: var(--panel); color: var(--text); padding: 9px 18px; cursor: pointer;
+  }
+  button.primary { background: var(--accent); border-color: var(--accent); color: #fff; }
+  button.primary:disabled { opacity: .45; cursor: not-allowed; }
+  button.ghost { background: transparent; }
+  button.small { padding: 4px 10px; font-size: 12.5px; font-weight: 500; }
+  .navbtns { display: flex; justify-content: space-between; margin-top: 18px; }
+
+  /* File lists */
+  .filedrop {
+    border: 2px dashed var(--border); border-radius: 12px; padding: 22px; text-align: center;
+    color: var(--muted); font-size: 14px; cursor: pointer; transition: border-color .15s;
+  }
+  .filedrop:hover, .filedrop.drag { border-color: var(--accent); }
+  ul.filelist { list-style: none; padding: 0; margin: 10px 0 0; }
+  ul.filelist li {
+    display: flex; align-items: center; gap: 10px; padding: 7px 10px; border: 1px solid var(--border);
+    border-radius: 8px; margin-bottom: 6px; font-size: 13.5px; background: var(--bg);
+  }
+  ul.filelist li .name { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  ul.filelist li .meta { color: var(--muted); font-size: 12px; flex: none; }
+
+  /* Accounts editor */
+  .acctrow { display: flex; gap: 8px; margin-bottom: 8px; }
+  .acctrow input { flex: 1; }
+
+  /* Log console */
+  pre.console {
+    background: var(--code-bg); color: var(--code-text); border-radius: 10px; padding: 14px;
+    font: 12px/1.5 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    max-height: 340px; overflow: auto; white-space: pre-wrap; word-break: break-word; margin: 12px 0 0;
+  }
+  pre.console:empty::before { content: "Output will appear here…"; color: #5c6b7a; }
+
+  /* Engine status bar */
+  .enginebar {
+    position: fixed; left: 0; right: 0; bottom: 0; background: var(--panel);
+    border-top: 1px solid var(--border); padding: 9px 24px; font-size: 13px;
+    display: flex; align-items: center; gap: 10px; z-index: 5;
+  }
+  .enginebar .inner { max-width: 852px; margin: 0 auto; display: flex; align-items: center; gap: 10px; width: 100%; }
+  .pill { display: inline-flex; align-items: center; gap: 6px; padding: 3px 10px; border-radius: 999px; font-size: 12px; font-weight: 600; flex: none; }
+  .pill.loading { background: var(--warn-soft); color: var(--warn); }
+  .pill.ready { background: var(--ok-soft); color: var(--ok); }
+  .pill.error { background: var(--err-soft); color: var(--err); }
+  .spinner { width: 12px; height: 12px; border: 2px solid currentColor; border-right-color: transparent; border-radius: 50%; animation: spin .8s linear infinite; flex: none; }
+  @keyframes spin { to { transform: rotate(360deg); } }
+  .enginebar .detail { color: var(--muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  progress { width: 140px; height: 8px; accent-color: var(--accent); flex: none; }
+
+  .dl { display: flex; gap: 12px; flex-wrap: wrap; margin: 14px 0; }
+  a.dlbtn {
+    display: inline-flex; align-items: center; gap: 8px; padding: 12px 20px; border-radius: 10px;
+    background: var(--accent); color: #fff; text-decoration: none; font-weight: 700;
+  }
+  a.dlbtn.secondary { background: transparent; color: var(--text); border: 1px solid var(--border); }
+  code { background: var(--bg); border: 1px solid var(--border); border-radius: 5px; padding: 1px 5px; font-size: 12.5px; }
+  a { color: var(--accent); }
+  .hint { font-size: 12.5px; color: var(--muted); margin-top: 4px; }
+  details.adv { margin-top: 14px; font-size: 13.5px; }
+  details.adv summary { cursor: pointer; color: var(--muted); font-weight: 600; }
+  footer.page { max-width: 900px; margin: 24px auto 60px; padding: 0 24px; color: var(--muted); font-size: 12.5px; }
+</style>
+</head>
+<body>
+
+<header class="app">
+  <h1><span class="flag">🇨🇭</span> OpenSteuerAuszug <span style="font-weight:400;color:var(--muted);font-size:15px">— in your browser</span></h1>
+  <p>Generate a Swiss eCH-0196 tax statement (Steuerauszug) from broker data. Everything runs locally in this page — your financial data never leaves your computer.</p>
+</header>
+
+<main>
+  <ol class="stepper" id="stepper"></ol>
+
+  <!-- Step 1: Welcome -->
+  <section class="step" data-step="0">
+    <div class="card">
+      <h2>Welcome</h2>
+      <p class="lead">This wizard walks you through generating your Steuerauszug in five short steps.</p>
+      <ul style="font-size:14px;margin:0 0 10px;padding-left:20px">
+        <li><b>Your details</b> — name, canton, tax year and broker (remembered on this device).</li>
+        <li><b>Kursliste</b> — the official ESTV securities list for your tax year.</li>
+        <li><b>Broker files</b> — the statements you exported from your broker.</li>
+        <li><b>Generate</b> — the processing pipeline runs right here in your browser.</li>
+        <li><b>Download</b> — your PDF (and XML) Steuerauszug.</li>
+      </ul>
+      <div class="notice">
+        <b>Disclaimer.</b> This tool is not formally audited. Tax values are computed on a best-effort,
+        informational basis. <b>You</b> are responsible for verifying every figure before submitting your
+        tax return, and for the contents of that return. See the
+        <a href="https://github.com/vroonhof/opensteuerauszug/blob/main/docs/user_guide.md" target="_blank" rel="noopener">user guide</a>.
+      </div>
+      <label class="checkbox">
+        <input type="checkbox" id="ack">
+        <span>I understand that I must verify the generated statement myself and that I remain responsible for my tax return.</span>
+      </label>
+      <div class="notice" id="devModeNotice" style="display:none">
+        This is the un-built template. Run <code>python scripts/build_web_app.py</code> to produce the
+        distributable <code>opensteuerauszug.html</code> with the application code embedded.
+      </div>
+      <details class="adv">
+        <summary>Advanced: runtime options</summary>
+        <p style="font-size:13px;margin:10px 0 6px">The Python runtime (Pyodide) and library dependencies are
+        downloaded once from public CDNs (~40&nbsp;MB, cached by your browser afterwards). Your personal data is
+        never uploaded anywhere. To use a self-hosted copy instead, set the base URL below and reload.</p>
+        <label class="field"><b>Pyodide base URL</b>
+          <input type="text" id="pyodideBase" placeholder="(default: jsDelivr CDN)">
+        </label>
+      </details>
+    </div>
+    <div class="navbtns">
+      <span></span>
+      <button class="primary" id="btnStart" disabled>Get started →</button>
+    </div>
+  </section>
+
+  <!-- Step 2: Settings -->
+  <section class="step" data-step="1">
+    <div class="card">
+      <h2>Your details</h2>
+      <p class="lead">These are stored only in this browser (local storage) and reused next time.</p>
+      <div class="grid">
+        <label class="field"><b>Full name</b>
+          <input type="text" id="fullName" placeholder="Maxine Muster" autocomplete="name">
+        </label>
+        <label class="field"><b>Canton</b>
+          <select id="canton"></select>
+        </label>
+        <label class="field"><b>Tax year</b>
+          <input type="number" id="taxYear" min="2000" max="2100" step="1">
+        </label>
+        <label class="field"><b>Document language</b>
+          <select id="language">
+            <option value="de">Deutsch</option>
+            <option value="en">English</option>
+            <option value="fr">Français</option>
+            <option value="it">Italiano</option>
+          </select>
+        </label>
+        <label class="field"><b>Broker / importer</b>
+          <select id="importer">
+            <option value="ibkr">Interactive Brokers (Flex Query XML)</option>
+            <option value="schwab">Charles Schwab (statement exports)</option>
+            <option value="fidelity">Fidelity (experimental)</option>
+            <option value="degiro">DEGIRO (experimental)</option>
+          </select>
+        </label>
+        <label class="field"><b>Tax value calculation</b>
+          <select id="taxLevel">
+            <option value="kursliste">Kursliste (recommended)</option>
+            <option value="minimal">Minimal (let tax software compute)</option>
+          </select>
+        </label>
+      </div>
+      <div id="acctBox" style="margin-top:16px">
+        <b style="font-size:13.5px">Accounts</b>
+        <p class="hint" id="acctHint"></p>
+        <div id="acctRows"></div>
+        <button class="small" id="btnAddAcct" type="button">+ Add account</button>
+      </div>
+      <div class="notice" id="experimentalNotice" style="display:none">
+        This importer is <b>experimental</b>. It will be enabled via
+        <code>experimental_importers = true</code> in the generated configuration — double-check results carefully.
+      </div>
+      <details class="adv" id="tomlBox">
+        <summary>Advanced: configuration file (config.toml)</summary>
+        <p style="font-size:13px;margin:10px 0 6px">The settings above are translated into the configuration below.
+          Tick the box to edit it directly (for broker/account overrides described in the
+          <a href="https://github.com/vroonhof/opensteuerauszug/blob/main/docs/config.md" target="_blank" rel="noopener">configuration guide</a>).</p>
+        <label class="checkbox"><input type="checkbox" id="tomlCustom"><span>Edit the TOML manually (overrides the form above)</span></label>
+        <textarea class="toml" id="tomlText" readonly spellcheck="false"></textarea>
+      </details>
+    </div>
+    <div class="navbtns">
+      <button class="ghost" data-nav="back">← Back</button>
+      <button class="primary" data-nav="next">Next: Kursliste →</button>
+    </div>
+  </section>
+
+  <!-- Step 3: Kursliste -->
+  <section class="step" data-step="2">
+    <div class="card">
+      <h2>Kursliste (official securities list)</h2>
+      <p class="lead">The pipeline needs the official ESTV Kursliste for your tax year to look up
+        valor numbers, exchange rates and tax values. It is cached in your browser, so you normally
+        only do this once per year.</p>
+      <ol style="font-size:14px;padding-left:20px;margin:0 0 12px">
+        <li>Download the ZIP marked <b>“Initial”</b> (latest version) for your tax year from
+          <a href="https://www.ictax.admin.ch/extern/en.html#/xml" target="_blank" rel="noopener">ictax.admin.ch</a> and unzip it.</li>
+        <li>Add the resulting <code>kursliste_YYYY.xml</code> below.</li>
+      </ol>
+      <p class="hint">Tip: the XML is large (&gt;100&nbsp;MB) and takes a while to parse in the browser. If you also use the
+        command line tool, <code>opensteuerauszug kursliste download --year YYYY</code> produces a much faster
+        <code>kursliste_YYYY.sqlite</code> which you can add here instead.</p>
+      <div class="filedrop" id="dropKursliste">
+        <b>Drop the Kursliste file here</b> or click to choose<br>
+        <span class="hint">kursliste_YYYY.xml or kursliste_YYYY.sqlite</span>
+        <input type="file" id="fileKursliste" accept=".xml,.sqlite" multiple hidden>
+      </div>
+      <ul class="filelist" id="listKursliste"></ul>
+      <div class="notice" id="kurslisteYearWarn" style="display:none"></div>
+      <div class="notice error" id="idbWarn" style="display:none">
+        Your browser did not allow persistent storage for this page, so the Kursliste will need to be
+        re-added next time you open it. Everything else still works.
+      </div>
+    </div>
+    <div class="navbtns">
+      <button class="ghost" data-nav="back">← Back</button>
+      <button class="primary" data-nav="next">Next: Broker files →</button>
+    </div>
+  </section>
+
+  <!-- Step 4: Broker files -->
+  <section class="step" data-step="3">
+    <div class="card">
+      <h2>Broker files</h2>
+      <p class="lead" id="brokerLead"></p>
+      <div class="notice" id="brokerHelp"></div>
+      <div class="filedrop" id="dropBroker">
+        <b>Drop your broker file(s) here</b> or click to choose
+        <input type="file" id="fileBroker" multiple hidden>
+      </div>
+      <ul class="filelist" id="listBroker"></ul>
+      <details class="adv">
+        <summary>Optional: attach supporting PDFs</summary>
+        <p style="font-size:13px;margin:10px 0 6px">These pages are prepended/appended to the final PDF unchanged
+          (e.g. an original broker statement or a 1042-S form).</p>
+        <div class="grid">
+          <label class="field"><b>Prepend (before statement)</b>
+            <input type="file" id="filePre" accept=".pdf" multiple>
+          </label>
+          <label class="field"><b>Append (after statement)</b>
+            <input type="file" id="filePost" accept=".pdf" multiple>
+          </label>
+        </div>
+      </details>
+    </div>
+    <div class="navbtns">
+      <button class="ghost" data-nav="back">← Back</button>
+      <button class="primary" data-nav="next">Next: Generate →</button>
+    </div>
+  </section>
+
+  <!-- Step 5: Generate -->
+  <section class="step" data-step="4">
+    <div class="card">
+      <h2>Generate</h2>
+      <p class="lead">Review the summary, then run the pipeline. Processing happens entirely in this page and can
+        take from a few seconds up to several minutes (a large Kursliste XML is the slow part).</p>
+      <div id="runSummary" style="font-size:14px"></div>
+      <div class="notice error" id="runBlockers" style="display:none"></div>
+      <div class="row" style="margin-top:14px">
+        <button class="primary" id="btnRun" disabled>▶ Generate Steuerauszug</button>
+        <span class="pill loading" id="runStatus" style="display:none"><span class="spinner"></span> Running…</span>
+      </div>
+      <pre class="console" id="runLog"></pre>
+    </div>
+    <div class="navbtns">
+      <button class="ghost" data-nav="back">← Back</button>
+      <span></span>
+    </div>
+  </section>
+
+  <!-- Step 6: Results -->
+  <section class="step" data-step="5">
+    <div class="card">
+      <h2>Your Steuerauszug is ready</h2>
+      <p class="lead" id="resultLead"></p>
+      <div class="dl" id="downloads"></div>
+      <div class="notice" id="resultWarnings" style="display:none"></div>
+      <div class="notice ok">
+        <b>Before you file — verify the document:</b>
+        <ul style="margin:6px 0 0;padding-left:18px">
+          <li>No unresolved errors or warnings in the processing log.</li>
+          <li>All securities are present and mapped to the correct valor number.</li>
+          <li>All transactions and end-of-year positions are correct.</li>
+          <li>Cash balances and interest totals are correct.</li>
+          <li>After importing into your tax software, <b>recalculate</b> the tax values there.</li>
+        </ul>
+      </div>
+      <details class="adv">
+        <summary>Processing log</summary>
+        <pre class="console" id="resultLog"></pre>
+      </details>
+    </div>
+    <div class="navbtns">
+      <button class="ghost" data-nav="back">← Back to generate</button>
+      <button id="btnRestart">Start a new run</button>
+    </div>
+  </section>
+</main>
+
+<div class="enginebar">
+  <div class="inner">
+    <span class="pill loading" id="enginePill"><span class="spinner"></span> <span id="engineState">Waiting</span></span>
+    <progress id="engineProgress" max="100" value="0"></progress>
+    <span class="detail" id="engineDetail">Python engine not started yet.</span>
+  </div>
+</div>
+
+<footer class="page">
+  OpenSteuerAuszug <span id="verInfo"></span> — MIT licensed open source software, no warranty.
+  <a href="https://github.com/vroonhof/opensteuerauszug" target="_blank" rel="noopener">Source &amp; documentation</a>.
+  This page makes no network requests other than downloading the Python runtime and open-source libraries.
+</footer>
+
+<!-- The application bundle (wheels etc.) is injected here by scripts/build_web_app.py -->
+<script type="application/json" id="osa-bundle">__OSA_BUNDLE_JSON__</script>
+
+<!-- Web worker source: runs Pyodide off the main thread so the UI stays responsive -->
+<script type="text/js-worker" id="osa-worker-src">
+"use strict";
+let pyodide = null;
+
+function post(msg, transfer) { self.postMessage(msg, transfer || []); }
+function progress(stage, detail, pct) { post({ type: "progress", stage, detail, pct }); }
+
+function b64ToBytes(b64) {
+  const bin = atob(b64);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return bytes;
+}
+
+async function init(cfg) {
+  try {
+    progress("runtime", "Downloading Python runtime…", 5);
+    importScripts(cfg.indexURL + "pyodide.js");
+    pyodide = await loadPyodide({ indexURL: cfg.indexURL });
+    progress("runtime", "Python runtime ready. Fetching libraries…", 25);
+
+    await pyodide.loadPackage("micropip", { messageCallback: () => {} });
+    // sqlite3 is a separate loadable package in Pyodide; the fast Kursliste
+    // path uses it. Tolerate failure for runtimes where it is built in.
+    try { await pyodide.loadPackage("sqlite3", { messageCallback: () => {} }); } catch (e) {}
+    const micropip = pyodide.pyimport("micropip");
+
+    // Install PyPI dependencies first (micropip resolves binary packages such
+    // as lxml/Pillow from the Pyodide distribution automatically) …
+    const reqs = cfg.bundle.requirements;
+    for (let i = 0; i < reqs.length; i++) {
+      progress("deps", "Installing " + reqs[i].replace(/[<>=!~;].*$/, "") + "…",
+               25 + Math.round(55 * (i / reqs.length)));
+      await micropip.install.callKwargs(reqs[i], {});
+    }
+
+    // … then the application wheels that are embedded in this HTML file.
+    progress("app", "Installing OpenSteuerAuszug…", 82);
+    pyodide.FS.mkdirTree("/wheels");
+    const wheelPaths = [];
+    for (const wheel of cfg.bundle.wheels) {
+      const path = "/wheels/" + wheel.name;
+      pyodide.FS.writeFile(path, b64ToBytes(wheel.data));
+      wheelPaths.push("emfs:" + path);
+    }
+    await micropip.install.callKwargs(wheelPaths, { deps: false });
+
+    progress("app", "Preparing workspace…", 94);
+    pyodide.runPython(`
+import json
+from opensteuerauszug.util import web_runner
+import opensteuerauszug
+_layout = web_runner.ensure_workspace("/work")
+_version = opensteuerauszug.__version__
+`);
+    if (cfg.bundle.identifiersCsv) {
+      pyodide.FS.writeFile("/work/config/security_identifiers.csv",
+                           b64ToBytes(cfg.bundle.identifiersCsv));
+    }
+    const version = pyodide.globals.get("_version");
+    post({ type: "ready", version: String(version) });
+  } catch (err) {
+    post({ type: "init-error", message: String(err && err.message || err) });
+  }
+}
+
+function resetDir(path) {
+  // Remove and recreate a workspace directory between runs.
+  const FS = pyodide.FS;
+  try {
+    for (const entry of FS.readdir(path)) {
+      if (entry === "." || entry === "..") continue;
+      const full = path + "/" + entry;
+      const mode = FS.stat(full).mode;
+      if (FS.isDir(mode)) { resetDir(full); FS.rmdir(full); }
+      else FS.unlink(full);
+    }
+  } catch (e) { FS.mkdirTree(path); }
+}
+
+async function run(job) {
+  if (!pyodide) { post({ type: "done", result: { success: false, log: "Engine not ready." } }); return; }
+  const FS = pyodide.FS;
+  try {
+    for (const dir of ["/work/input", "/work/kursliste", "/work/output", "/work/ambles"])
+      { FS.mkdirTree(dir); resetDir(dir); }
+
+    for (const f of job.brokerFiles)
+      FS.writeFile("/work/input/" + f.name, new Uint8Array(f.buffer));
+    for (const f of job.kurslisteFiles)
+      FS.writeFile("/work/kursliste/" + f.name, new Uint8Array(f.buffer));
+
+    const extraArgs = [];
+    for (const f of job.preAmble) {
+      const p = "/work/ambles/pre_" + f.name;
+      FS.writeFile(p, new Uint8Array(f.buffer));
+      extraArgs.push("--pre-amble", p);
+    }
+    for (const f of job.postAmble) {
+      const p = "/work/ambles/post_" + f.name;
+      FS.writeFile(p, new Uint8Array(f.buffer));
+      extraArgs.push("--post-amble", p);
+    }
+
+    FS.writeFile("/work/config/config.toml", job.configToml);
+
+    const inputPath = job.singleInputFile
+      ? "/work/input/" + job.brokerFiles[0].name
+      : "/work/input";
+
+    const params = {
+      input_path: inputPath,
+      output_pdf: "/work/output/steuerauszug.pdf",
+      xml_output: "/work/output/steuerauszug.xml",
+      importer: job.importer,
+      tax_year: job.taxYear,
+      kursliste_dir: "/work/kursliste",
+      config_path: "/work/config/config.toml",
+      identifiers_csv: "/work/config/security_identifiers.csv",
+      tax_calculation_level: job.taxLevel,
+      extra_args: extraArgs,
+    };
+
+    pyodide.globals.set("_params_json", JSON.stringify(params));
+    pyodide.globals.set("_log_cb", (line) => post({ type: "log", line: String(line) }));
+    const resultJson = await pyodide.runPythonAsync(`
+import json
+from opensteuerauszug.util import web_runner
+_r = web_runner.run_process(**json.loads(_params_json), on_output=_log_cb)
+json.dumps(_r)
+`);
+    const result = JSON.parse(resultJson);
+    const payload = { success: result.success, exitCode: result.exit_code, files: [] };
+    const transfers = [];
+    for (const [kind, path] of Object.entries(result.outputs || {})) {
+      const data = FS.readFile(path);
+      payload.files.push({ kind, name: path.split("/").pop(), buffer: data.buffer });
+      transfers.push(data.buffer);
+    }
+    post({ type: "done", result: payload }, transfers);
+  } catch (err) {
+    post({ type: "log", line: "Internal error: " + String(err && err.message || err) });
+    post({ type: "done", result: { success: false, exitCode: -1, files: [] } });
+  }
+}
+
+self.onmessage = (e) => {
+  const msg = e.data;
+  if (msg.type === "init") init(msg);
+  else if (msg.type === "run") run(msg.job);
+};
+</script>
+
+<script>
+"use strict";
+/* ============================== bundle ================================= */
+let BUNDLE = null;
+try { BUNDLE = JSON.parse(document.getElementById("osa-bundle").textContent); } catch (e) { /* template mode */ }
+
+const PYODIDE_VERSION = "0.29.4";
+const DEFAULT_PYODIDE_BASE = "https://cdn.jsdelivr.net/pyodide/v" + PYODIDE_VERSION + "/full/";
+
+/* ============================== state ================================== */
+const CANTONS = ["AG","AI","AR","BE","BL","BS","FR","GE","GL","GR","JU","LU","NE","NW","OW",
+                 "SG","SH","SO","SZ","TG","TI","UR","VD","VS","ZG","ZH"];
+const SETTINGS_KEY = "osa.settings.v1";
+
+const defaultSettings = () => ({
+  acknowledged: false,
+  fullName: "",
+  canton: "ZH",
+  taxYear: new Date().getFullYear() - 1,
+  language: "de",
+  importer: "ibkr",
+  taxLevel: "kursliste",
+  accounts: [],
+  tomlCustom: false,
+  tomlText: "",
+  pyodideBase: "",
+});
+
+let settings = defaultSettings();
+try { Object.assign(settings, JSON.parse(localStorage.getItem(SETTINGS_KEY) || "{}")); } catch (e) {}
+function saveSettings() { try { localStorage.setItem(SETTINGS_KEY, JSON.stringify(settings)); } catch (e) {} }
+
+const state = {
+  step: 0,
+  engine: "idle",         // idle | loading | ready | error
+  kurslisteFiles: [],      // {name, size, blob, fromCache}
+  brokerFiles: [],         // File[]
+  running: false,
+  lastLog: [],
+  results: null,
+};
+
+/* ============================ utilities ================================ */
+const $ = (id) => document.getElementById(id);
+function fmtSize(n) {
+  if (n > 1048576) return (n / 1048576).toFixed(1) + " MB";
+  if (n > 1024) return (n / 1024).toFixed(0) + " kB";
+  return n + " B";
+}
+function tomlStr(s) { return '"' + String(s).replace(/\\/g, "\\\\").replace(/"/g, '\\"') + '"'; }
+function sanitizeAlias(s, i) {
+  const a = String(s || "").replace(/[^A-Za-z0-9_-]/g, "_");
+  return a || ("account_" + (i + 1));
+}
+
+/* ====================== configuration generation ====================== */
+const EXPERIMENTAL = { fidelity: true, degiro: true };
+const ACCOUNTS_REQUIRED = { schwab: true, fidelity: true };
+
+function generateToml() {
+  const lines = ["# Generated by the OpenSteuerAuszug web app", "[general]"];
+  if (settings.canton) lines.push("canton = " + tomlStr(settings.canton));
+  if (settings.fullName) lines.push("full_name = " + tomlStr(settings.fullName));
+  lines.push("language = " + tomlStr(settings.language));
+  if (EXPERIMENTAL[settings.importer]) lines.push("experimental_importers = true");
+  const accts = settings.accounts.filter((a) => a.number);
+  accts.forEach((a, i) => {
+    lines.push("");
+    lines.push("[brokers." + settings.importer + ".accounts." + sanitizeAlias(a.alias, i) + "]");
+    lines.push("account_number = " + tomlStr(a.number));
+    if (a.name) lines.push("full_name = " + tomlStr(a.name));
+  });
+  return lines.join("\n") + "\n";
+}
+function effectiveToml() { return settings.tomlCustom && settings.tomlText ? settings.tomlText : generateToml(); }
+
+/* ============================= stepper ================================= */
+const STEPS = ["Welcome", "Your details", "Kursliste", "Broker files", "Generate", "Download"];
+function renderStepper() {
+  const ol = $("stepper");
+  ol.innerHTML = "";
+  STEPS.forEach((name, i) => {
+    const li = document.createElement("li");
+    li.className = (i === state.step ? "active" : "") + (i < state.step ? " done clickable" : "");
+    li.innerHTML = '<span class="dot">' + (i < state.step ? "✓" : i + 1) + "</span>" + name;
+    if (i < state.step) li.onclick = () => go(i);
+    ol.appendChild(li);
+  });
+  document.querySelectorAll("section.step").forEach((s) =>
+    s.classList.toggle("active", Number(s.dataset.step) === state.step));
+}
+function go(step) {
+  state.step = Math.max(0, Math.min(STEPS.length - 1, step));
+  if (state.step === 3) renderBrokerStep();
+  if (state.step === 4) renderRunSummary();
+  renderStepper();
+  window.scrollTo({ top: 0 });
+}
+document.querySelectorAll("[data-nav]").forEach((btn) => {
+  btn.onclick = () => go(state.step + (btn.dataset.nav === "next" ? 1 : -1));
+});
+
+/* ======================== step 1: welcome ============================= */
+$("ack").checked = !!settings.acknowledged;
+$("btnStart").disabled = !settings.acknowledged;
+$("ack").onchange = () => {
+  settings.acknowledged = $("ack").checked;
+  $("btnStart").disabled = !settings.acknowledged;
+  saveSettings();
+};
+$("btnStart").onclick = () => go(1);
+$("pyodideBase").value = settings.pyodideBase || "";
+$("pyodideBase").onchange = () => { settings.pyodideBase = $("pyodideBase").value.trim(); saveSettings(); };
+if (!BUNDLE) $("devModeNotice").style.display = "";
+
+/* ======================== step 2: settings ============================ */
+CANTONS.forEach((c) => {
+  const o = document.createElement("option");
+  o.value = c; o.textContent = c;
+  $("canton").appendChild(o);
+});
+function bindField(id, key, isNumber) {
+  $(id).value = settings[key];
+  $(id).onchange = () => {
+    settings[key] = isNumber ? Number($(id).value) : $(id).value;
+    saveSettings();
+    refreshSettingsUi();
+  };
+}
+bindField("fullName", "fullName");
+bindField("canton", "canton");
+bindField("taxYear", "taxYear", true);
+bindField("language", "language");
+bindField("importer", "importer");
+bindField("taxLevel", "taxLevel");
+
+function renderAccounts() {
+  const box = $("acctRows");
+  box.innerHTML = "";
+  settings.accounts.forEach((acct, i) => {
+    const row = document.createElement("div");
+    row.className = "acctrow";
+    const alias = document.createElement("input");
+    alias.placeholder = "alias (e.g. main)"; alias.value = acct.alias || "";
+    alias.onchange = () => { acct.alias = alias.value; saveSettings(); refreshToml(); };
+    const num = document.createElement("input");
+    num.placeholder = "account number"; num.value = acct.number || "";
+    num.onchange = () => { acct.number = num.value; saveSettings(); refreshToml(); };
+    const del = document.createElement("button");
+    del.type = "button"; del.className = "small"; del.textContent = "✕";
+    del.onclick = () => { settings.accounts.splice(i, 1); saveSettings(); renderAccounts(); refreshToml(); };
+    row.append(alias, num, del);
+    box.appendChild(row);
+  });
+}
+$("btnAddAcct").onclick = () => { settings.accounts.push({ alias: "", number: "" }); renderAccounts(); };
+
+function refreshToml() {
+  if (!settings.tomlCustom) { settings.tomlText = generateToml(); saveSettings(); }
+  $("tomlText").value = settings.tomlCustom ? settings.tomlText : generateToml();
+  $("tomlText").readOnly = !settings.tomlCustom;
+}
+$("tomlCustom").checked = !!settings.tomlCustom;
+$("tomlCustom").onchange = () => {
+  settings.tomlCustom = $("tomlCustom").checked;
+  if (settings.tomlCustom && !settings.tomlText) settings.tomlText = generateToml();
+  saveSettings(); refreshToml();
+};
+$("tomlText").onchange = () => {
+  if (settings.tomlCustom) { settings.tomlText = $("tomlText").value; saveSettings(); }
+};
+
+function refreshSettingsUi() {
+  $("experimentalNotice").style.display = EXPERIMENTAL[settings.importer] ? "" : "none";
+  const required = ACCOUNTS_REQUIRED[settings.importer];
+  $("acctHint").textContent = required
+    ? "This importer needs at least one account number so statements can be matched (see the broker guide)."
+    : "Optional for this importer — add account-specific overrides only if you need them.";
+  refreshToml();
+}
+renderAccounts();
+refreshSettingsUi();
+
+/* ==================== IndexedDB kursliste cache ======================== */
+let idb = null;
+function idbOpen() {
+  return new Promise((resolve) => {
+    if (!("indexedDB" in window)) return resolve(null);
+    const req = indexedDB.open("opensteuerauszug", 1);
+    req.onupgradeneeded = () => req.result.createObjectStore("files", { keyPath: "name" });
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => resolve(null);
+  });
+}
+function idbPut(entry) {
+  return new Promise((resolve) => {
+    if (!idb) return resolve(false);
+    const tx = idb.transaction("files", "readwrite");
+    tx.objectStore("files").put(entry);
+    tx.oncomplete = () => resolve(true);
+    tx.onerror = () => resolve(false);
+  });
+}
+function idbDelete(name) {
+  return new Promise((resolve) => {
+    if (!idb) return resolve(false);
+    const tx = idb.transaction("files", "readwrite");
+    tx.objectStore("files").delete(name);
+    tx.oncomplete = () => resolve(true);
+    tx.onerror = () => resolve(false);
+  });
+}
+function idbAll() {
+  return new Promise((resolve) => {
+    if (!idb) return resolve([]);
+    const req = idb.transaction("files").objectStore("files").getAll();
+    req.onsuccess = () => resolve(req.result || []);
+    req.onerror = () => resolve([]);
+  });
+}
+
+/* ======================= step 3: kursliste ============================= */
+function renderKursliste() {
+  const ul = $("listKursliste");
+  ul.innerHTML = "";
+  state.kurslisteFiles.forEach((f) => {
+    const li = document.createElement("li");
+    li.innerHTML = '<span class="name">📊 ' + f.name + '</span><span class="meta">' +
+      fmtSize(f.size) + (f.fromCache ? " · cached" : "") + "</span>";
+    const del = document.createElement("button");
+    del.className = "small"; del.textContent = "Remove";
+    del.onclick = async () => {
+      state.kurslisteFiles = state.kurslisteFiles.filter((x) => x.name !== f.name);
+      await idbDelete(f.name);
+      renderKursliste();
+    };
+    li.appendChild(del);
+    ul.appendChild(li);
+  });
+  const warn = $("kurslisteYearWarn");
+  const year = String(settings.taxYear);
+  if (state.kurslisteFiles.length && !state.kurslisteFiles.some((f) => f.name.includes(year))) {
+    warn.textContent = "None of the added files mentions " + year + " in its name. Files must be named " +
+      "kursliste_" + year + ".xml (or .sqlite) to be picked up for tax year " + year + ".";
+    warn.style.display = "";
+  } else warn.style.display = "none";
+}
+async function addKurslisteFiles(files) {
+  for (const file of files) {
+    if (!/\.(xml|sqlite)$/i.test(file.name)) continue;
+    state.kurslisteFiles = state.kurslisteFiles.filter((x) => x.name !== file.name);
+    state.kurslisteFiles.push({ name: file.name, size: file.size, blob: file, fromCache: false });
+    await idbPut({ name: file.name, size: file.size, blob: file, added: Date.now() });
+  }
+  renderKursliste();
+}
+function wireDrop(dropId, inputId, handler) {
+  const drop = $(dropId), input = $(inputId);
+  drop.onclick = () => input.click();
+  input.onchange = () => { handler(Array.from(input.files)); input.value = ""; };
+  drop.ondragover = (e) => { e.preventDefault(); drop.classList.add("drag"); };
+  drop.ondragleave = () => drop.classList.remove("drag");
+  drop.ondrop = (e) => {
+    e.preventDefault(); drop.classList.remove("drag");
+    handler(Array.from(e.dataTransfer.files));
+  };
+}
+wireDrop("dropKursliste", "fileKursliste", addKurslisteFiles);
+
+/* ====================== step 4: broker files =========================== */
+const BROKER_INFO = {
+  ibkr: {
+    lead: "Interactive Brokers: one Flex Query XML file covering the whole tax year.",
+    help: 'Create a Flex Query with the sections described in the <a target="_blank" rel="noopener" ' +
+      'href="https://github.com/vroonhof/opensteuerauszug/blob/main/docs/importer_ibkr.md">IBKR guide</a> ' +
+      "and download it as XML. Add that single file below.",
+    accept: ".xml", multiple: false,
+  },
+  schwab: {
+    lead: "Charles Schwab: all exported statement files for the tax year.",
+    help: 'Export the files described in the <a target="_blank" rel="noopener" ' +
+      'href="https://github.com/vroonhof/opensteuerauszug/blob/main/docs/importer_schwab.md">Schwab guide</a> ' +
+      "(transaction history JSON/CSV, positions, equity awards) and add them all below.",
+    accept: "", multiple: true,
+  },
+  fidelity: {
+    lead: "Fidelity (experimental): all exported statement files for the tax year.",
+    help: 'See the <a target="_blank" rel="noopener" ' +
+      'href="https://github.com/vroonhof/opensteuerauszug/blob/main/docs/importer_fidelity.md">Fidelity guide</a> ' +
+      "for the required exports, then add them all below.",
+    accept: "", multiple: true,
+  },
+  degiro: {
+    lead: "DEGIRO (experimental): the account and transaction CSV exports for the tax year.",
+    help: 'See the <a target="_blank" rel="noopener" ' +
+      'href="https://github.com/vroonhof/opensteuerauszug/blob/main/docs/importer_degiro.md">DEGIRO guide</a> ' +
+      "for the required exports, then add them all below.",
+    accept: ".csv", multiple: true,
+  },
+};
+function renderBrokerStep() {
+  const info = BROKER_INFO[settings.importer];
+  $("brokerLead").textContent = info.lead;
+  $("brokerHelp").innerHTML = info.help;
+  $("fileBroker").accept = info.accept;
+  $("fileBroker").multiple = info.multiple;
+  renderBrokerFiles();
+}
+function renderBrokerFiles() {
+  const ul = $("listBroker");
+  ul.innerHTML = "";
+  state.brokerFiles.forEach((f, i) => {
+    const li = document.createElement("li");
+    li.innerHTML = '<span class="name">📄 ' + f.name + '</span><span class="meta">' + fmtSize(f.size) + "</span>";
+    const del = document.createElement("button");
+    del.className = "small"; del.textContent = "Remove";
+    del.onclick = () => { state.brokerFiles.splice(i, 1); renderBrokerFiles(); };
+    li.appendChild(del);
+    ul.appendChild(li);
+  });
+}
+wireDrop("dropBroker", "fileBroker", (files) => {
+  const info = BROKER_INFO[settings.importer];
+  if (!info.multiple) state.brokerFiles = files.slice(0, 1);
+  else state.brokerFiles.push(...files);
+  renderBrokerFiles();
+});
+
+/* ========================= engine / worker ============================= */
+let worker = null;
+function setEngine(cls, label, detail, pct) {
+  state.engine = cls;
+  const pill = $("enginePill");
+  pill.className = "pill " + (cls === "ready" ? "ready" : cls === "error" ? "error" : "loading");
+  pill.innerHTML = (cls === "loading" ? '<span class="spinner"></span> ' : cls === "ready" ? "✓ " : "✕ ") +
+    "<span>" + label + "</span>";
+  $("engineDetail").textContent = detail || "";
+  if (pct != null) $("engineProgress").value = pct;
+  $("engineProgress").style.display = cls === "loading" ? "" : "none";
+  refreshRunButton();
+}
+function startEngine() {
+  if (worker || !BUNDLE) return;
+  const src = document.getElementById("osa-worker-src").textContent;
+  worker = new Worker(URL.createObjectURL(new Blob([src], { type: "text/javascript" })));
+  worker.onmessage = (e) => {
+    const msg = e.data;
+    if (msg.type === "progress") setEngine("loading", "Loading engine", msg.detail, msg.pct);
+    else if (msg.type === "ready") {
+      setEngine("ready", "Engine ready", "OpenSteuerAuszug " + msg.version + " · Pyodide " + PYODIDE_VERSION);
+      $("verInfo").textContent = "v" + msg.version;
+    }
+    else if (msg.type === "init-error")
+      setEngine("error", "Engine failed", msg.message + " — check your internet connection and reload.");
+    else if (msg.type === "log") {
+      state.lastLog.push(msg.line);
+      const log = $("runLog");
+      log.textContent += msg.line + "\n";
+      log.scrollTop = log.scrollHeight;
+    }
+    else if (msg.type === "done") onRunDone(msg.result);
+  };
+  worker.onerror = (e) => setEngine("error", "Engine failed", e.message || "Worker error");
+  const params = new URLSearchParams(location.search);
+  const base = params.get("pyodide") || settings.pyodideBase || DEFAULT_PYODIDE_BASE;
+  const indexURL = base.endsWith("/") ? base : base + "/";
+  setEngine("loading", "Loading engine", "Starting…", 2);
+  worker.postMessage({ type: "init", indexURL, bundle: BUNDLE });
+}
+
+/* ========================= step 5: generate ============================ */
+function runBlockers() {
+  const problems = [];
+  if (!BUNDLE) problems.push("This template has not been built — run scripts/build_web_app.py.");
+  if (state.engine === "error") problems.push("The Python engine failed to load.");
+  if (state.engine !== "ready") problems.push("The Python engine is still loading (see the bar below).");
+  if (!state.kurslisteFiles.length) problems.push("No Kursliste file added (step 3).");
+  if (!state.brokerFiles.length) problems.push("No broker files added (step 4).");
+  if (settings.importer === "ibkr" && state.brokerFiles.length > 1)
+    problems.push("The IBKR importer expects a single Flex Query XML file.");
+  if (ACCOUNTS_REQUIRED[settings.importer] && !settings.tomlCustom &&
+      !settings.accounts.some((a) => a.number))
+    problems.push("This importer requires at least one account number (step 2).");
+  if (!settings.taxYear || settings.taxYear < 2000) problems.push("Tax year looks invalid (step 2).");
+  return problems;
+}
+function renderRunSummary() {
+  const rows = [
+    ["Tax year", settings.taxYear],
+    ["Broker", $("importer").selectedOptions[0].textContent],
+    ["Name", settings.fullName || "(not set)"],
+    ["Canton", settings.canton],
+    ["Calculation", settings.taxLevel === "kursliste" ? "Kursliste values" : "Minimal"],
+    ["Kursliste", state.kurslisteFiles.map((f) => f.name).join(", ") || "—"],
+    ["Broker files", state.brokerFiles.length + " file(s)"],
+  ];
+  $("runSummary").innerHTML = rows.map(([k, v]) =>
+    "<div><b style='display:inline-block;min-width:110px'>" + k + ":</b> " + String(v) + "</div>").join("");
+  refreshRunButton();
+}
+function refreshRunButton() {
+  if (state.step !== 4) return;
+  const problems = runBlockers();
+  const box = $("runBlockers");
+  if (problems.length && !(problems.length === 1 && state.engine === "loading")) {
+    box.innerHTML = "<b>Before you can run:</b><ul style='margin:6px 0 0;padding-left:18px'>" +
+      problems.map((p) => "<li>" + p + "</li>").join("") + "</ul>";
+    box.style.display = "";
+  } else box.style.display = "none";
+  $("btnRun").disabled = problems.length > 0 || state.running;
+}
+$("btnRun").onclick = async () => {
+  if (state.running) return;
+  state.running = true;
+  state.lastLog = [];
+  $("runLog").textContent = "";
+  $("runStatus").style.display = "";
+  $("btnRun").disabled = true;
+  try {
+    const toBuf = async (fileLike) => ({
+      name: fileLike.name,
+      buffer: await (fileLike.blob || fileLike).arrayBuffer(),
+    });
+    const job = {
+      importer: settings.importer,
+      taxYear: settings.taxYear,
+      taxLevel: settings.taxLevel,
+      configToml: effectiveToml(),
+      singleInputFile: settings.importer === "ibkr",
+      brokerFiles: await Promise.all(state.brokerFiles.map(toBuf)),
+      kurslisteFiles: await Promise.all(state.kurslisteFiles.map(toBuf)),
+      preAmble: await Promise.all(Array.from($("filePre").files).map(toBuf)),
+      postAmble: await Promise.all(Array.from($("filePost").files).map(toBuf)),
+    };
+    const transfers = [];
+    for (const list of [job.brokerFiles, job.kurslisteFiles, job.preAmble, job.postAmble])
+      for (const f of list) transfers.push(f.buffer);
+    worker.postMessage({ type: "run", job }, transfers);
+  } catch (err) {
+    $("runLog").textContent += "Failed to prepare files: " + err + "\n";
+    state.running = false;
+    $("runStatus").style.display = "none";
+    refreshRunButton();
+  }
+};
+function onRunDone(result) {
+  state.running = false;
+  state.results = result;
+  $("runStatus").style.display = "none";
+  refreshRunButton();
+  if (result.success) {
+    renderResults();
+    go(5);
+  } else {
+    const log = $("runLog");
+    log.textContent += "\n✕ Processing failed (exit code " + result.exitCode + "). " +
+      "Check the messages above — common causes are a missing Kursliste year, a wrong importer, " +
+      "or missing account configuration.\n";
+    log.scrollTop = log.scrollHeight;
+  }
+}
+
+/* ========================= step 6: results ============================= */
+function renderResults() {
+  const box = $("downloads");
+  box.innerHTML = "";
+  const year = settings.taxYear;
+  const labels = { pdf: "⬇ Steuerauszug PDF", xml: "⬇ eCH-0196 XML" };
+  const names = { pdf: "steuerauszug_" + year + ".pdf", xml: "steuerauszug_" + year + ".xml" };
+  const types = { pdf: "application/pdf", xml: "application/xml" };
+  for (const f of state.results.files) {
+    const a = document.createElement("a");
+    a.className = "dlbtn" + (f.kind === "xml" ? " secondary" : "");
+    a.textContent = labels[f.kind] || "⬇ " + f.name;
+    a.href = URL.createObjectURL(new Blob([f.buffer], { type: types[f.kind] || "application/octet-stream" }));
+    a.download = names[f.kind] || f.name;
+    box.appendChild(a);
+  }
+  $("resultLead").textContent = "Tax year " + year + " — import the PDF into your tax software " +
+    "(the machine-readable data is embedded in its barcodes). The XML is the same data for archival or validation.";
+  const warnLines = state.lastLog.filter((l) => /warning|error|mismatch/i.test(l));
+  const warnBox = $("resultWarnings");
+  if (warnLines.length) {
+    warnBox.innerHTML = "<b>The log contains " + warnLines.length +
+      " line(s) with warnings or errors — please review them:</b><br>" +
+      warnLines.slice(0, 12).map((l) => "· " + l.replace(/</g, "&lt;")).join("<br>") +
+      (warnLines.length > 12 ? "<br>…" : "");
+    warnBox.style.display = "";
+  } else warnBox.style.display = "none";
+  $("resultLog").textContent = state.lastLog.join("\n");
+}
+$("btnRestart").onclick = () => { go(3); };
+
+/* ============================== boot =================================== */
+renderStepper();
+go(settings.acknowledged ? 0 : 0);
+(async () => {
+  idb = await idbOpen();
+  if (!idb) $("idbWarn").style.display = "";
+  const cached = await idbAll();
+  for (const entry of cached) {
+    state.kurslisteFiles.push({
+      name: entry.name, size: entry.size, blob: entry.blob, fromCache: true,
+    });
+  }
+  renderKursliste();
+})();
+if (BUNDLE) startEngine();
+</script>
+</body>
+</html>

--- a/web/app_template.html
+++ b/web/app_template.html
@@ -274,9 +274,10 @@
           <a href="https://www.ictax.admin.ch/extern/en.html#/xml" target="_blank" rel="noopener">ictax.admin.ch</a> and unzip it.</li>
         <li>Add the resulting <code>kursliste_YYYY.xml</code> below.</li>
       </ol>
-      <p class="hint">Tip: the XML is large (&gt;100&nbsp;MB) and takes a while to parse in the browser. If you also use the
-        command line tool, <code>opensteuerauszug kursliste download --year YYYY</code> produces a much faster
-        <code>kursliste_YYYY.sqlite</code> which you can add here instead.</p>
+      <p class="hint">The XML is large (&gt;100&nbsp;MB), so the first run converts it to a compact database —
+        that takes a few minutes, after which the database is cached and the XML is no longer needed.
+        If you also use the command line tool, <code>opensteuerauszug kursliste download --year YYYY</code>
+        produces the same <code>kursliste_YYYY.sqlite</code>, which you can add here directly.</p>
       <div class="filedrop" id="dropKursliste">
         <b>Drop the Kursliste file here</b> or click to choose<br>
         <span class="hint">kursliste_YYYY.xml or kursliste_YYYY.sqlite</span>
@@ -331,7 +332,7 @@
     <div class="card">
       <h2>Generate</h2>
       <p class="lead">Review the summary, then run the pipeline. Processing happens entirely in this page and can
-        take from a few seconds up to several minutes (a large Kursliste XML is the slow part).</p>
+        take from a few seconds up to several minutes (converting a Kursliste XML on the first run is the slow part).</p>
       <div id="runSummary" style="font-size:14px"></div>
       <div class="notice error" id="runBlockers" style="display:none"></div>
       <div class="row" style="margin-top:14px">
@@ -494,6 +495,26 @@ async function run(job) {
     for (const f of job.kurslisteFiles)
       FS.writeFile("/work/kursliste/" + f.name, new Uint8Array(f.buffer));
 
+    pyodide.globals.set("_log_cb", (line) => post({ type: "log", line: String(line) }));
+
+    // A full Kursliste XML cannot be parsed directly in the browser (it needs
+    // ~30x its size in memory, far beyond the WebAssembly limit).  Convert any
+    // XML to SQLite with the streaming converter first and hand the result
+    // back to the page, which caches it for future runs.
+    if (job.kurslisteFiles.some((f) => /\.xml$/i.test(f.name))) {
+      post({ type: "log", line: "Converting Kursliste XML to a database (one-time; the result is cached in your browser)…" });
+      const convJson = await pyodide.runPythonAsync(`
+import json
+from opensteuerauszug.util import web_runner
+json.dumps(web_runner.convert_kursliste_xmls("/work/kursliste", on_output=_log_cb))
+`);
+      for (const c of JSON.parse(convJson).converted) {
+        const data = FS.readFile(c.path);
+        post({ type: "kursliste-converted", source: c.source, name: c.path.split("/").pop(),
+               buffer: data.buffer }, [data.buffer]);
+      }
+    }
+
     const extraArgs = [];
     for (const f of job.preAmble) {
       const p = "/work/ambles/pre_" + f.name;
@@ -526,7 +547,6 @@ async function run(job) {
     };
 
     pyodide.globals.set("_params_json", JSON.stringify(params));
-    pyodide.globals.set("_log_cb", (line) => post({ type: "log", line: String(line) }));
     const resultJson = await pyodide.runPythonAsync(`
 import json
 from opensteuerauszug.util import web_runner
@@ -931,6 +951,7 @@ function startEngine() {
       log.textContent += msg.line + "\n";
       log.scrollTop = log.scrollHeight;
     }
+    else if (msg.type === "kursliste-converted") onKurslisteConverted(msg);
     else if (msg.type === "done") onRunDone(msg.result);
   };
   worker.onerror = (e) => setEngine("error", "Engine failed", e.message || "Worker error", null,
@@ -1017,6 +1038,18 @@ $("btnRun").onclick = async () => {
     refreshRunButton();
   }
 };
+async function onKurslisteConverted(msg) {
+  // The worker converted an uploaded Kursliste XML to SQLite; keep only the
+  // (much faster) database from now on, both in memory and in the cache.
+  const blob = new Blob([msg.buffer], { type: "application/vnd.sqlite3" });
+  state.kurslisteFiles = state.kurslisteFiles.filter(
+    (x) => x.name !== msg.source && x.name !== msg.name);
+  state.kurslisteFiles.push({ name: msg.name, size: blob.size, blob, fromCache: true });
+  await idbDelete(msg.source);
+  await idbPut({ name: msg.name, size: blob.size, blob, added: Date.now() });
+  renderKursliste();
+}
+
 function onRunDone(result) {
   state.running = false;
   state.results = result;

--- a/web/app_template.html
+++ b/web/app_template.html
@@ -120,7 +120,10 @@
     border-top: 1px solid var(--border); padding: 9px 24px; font-size: 13px;
     display: flex; align-items: center; gap: 10px; z-index: 5;
   }
-  .enginebar .inner { max-width: 852px; margin: 0 auto; display: flex; align-items: center; gap: 10px; width: 100%; }
+  .enginebar .inner { max-width: 852px; margin: 0 auto; width: 100%; }
+  .enginebar .statusrow { display: flex; align-items: center; gap: 10px; }
+  .enginebar .statusrow button { flex: none; }
+  .enginebar #engineErrorBox { max-height: 40vh; margin: 8px 0 0; }
   .pill { display: inline-flex; align-items: center; gap: 6px; padding: 3px 10px; border-radius: 999px; font-size: 12px; font-weight: 600; flex: none; }
   .pill.loading { background: var(--warn-soft); color: var(--warn); }
   .pill.ready { background: var(--ok-soft); color: var(--ok); }
@@ -374,16 +377,20 @@
 
 <div class="enginebar">
   <div class="inner">
-    <span class="pill loading" id="enginePill"><span class="spinner"></span> <span id="engineState">Waiting</span></span>
-    <progress id="engineProgress" max="100" value="0"></progress>
-    <span class="detail" id="engineDetail">Python engine not started yet.</span>
+    <div class="statusrow">
+      <span class="pill loading" id="enginePill"><span class="spinner"></span> <span id="engineState">Waiting</span></span>
+      <progress id="engineProgress" max="100" value="0"></progress>
+      <span class="detail" id="engineDetail">Python engine not started yet.</span>
+      <button class="small ghost" id="engineDetailToggle" style="display:none">Show details</button>
+    </div>
+    <pre class="console" id="engineErrorBox" style="display:none"></pre>
   </div>
 </div>
 
 <footer class="page">
   OpenSteuerAuszug <span id="verInfo"></span> — MIT licensed open source software, no warranty.
   <a href="https://github.com/vroonhof/opensteuerauszug" target="_blank" rel="noopener">Source &amp; documentation</a>.
-  This page makes no network requests other than downloading the Python runtime and open-source libraries.
+  All application code is embedded in this file; the only network requests download the version-pinned Python runtime and its libraries.
 </footer>
 
 <!-- The application bundle (wheels etc.) is injected here by scripts/build_web_app.py -->
@@ -417,14 +424,18 @@ async function init(cfg) {
     try { await pyodide.loadPackage("sqlite3", { messageCallback: () => {} }); } catch (e) {}
     const micropip = pyodide.pyimport("micropip");
 
-    // Install PyPI dependencies first (micropip resolves binary packages such
-    // as lxml/Pillow from the Pyodide distribution automatically) …
-    const reqs = cfg.bundle.requirements;
-    for (let i = 0; i < reqs.length; i++) {
-      progress("deps", "Installing " + reqs[i].replace(/[<>=!~;].*$/, "") + "…",
-               25 + Math.round(55 * (i / reqs.length)));
-      await micropip.install.callKwargs(reqs[i], {});
-    }
+    // Load the packages that come from the version-pinned Pyodide
+    // distribution (binary builds such as lxml/Pillow).  Everything else is
+    // embedded in this file as wheels — the page never contacts PyPI.
+    const distPkgs = cfg.bundle.pyodidePackages || [];
+    let loaded = 0;
+    progress("deps", "Loading libraries…", 28);
+    await pyodide.loadPackage(distPkgs, { messageCallback: (m) => {
+      if (/^Loaded/.test(m)) {
+        loaded++;
+        progress("deps", m, 28 + Math.round(52 * (loaded / distPkgs.length)));
+      }
+    }});
 
     // … then the application wheels that are embedded in this HTML file.
     progress("app", "Installing OpenSteuerAuszug…", 82);
@@ -452,7 +463,8 @@ _version = opensteuerauszug.__version__
     const version = pyodide.globals.get("_version");
     post({ type: "ready", version: String(version) });
   } catch (err) {
-    post({ type: "init-error", message: String(err && err.message || err) });
+    post({ type: "init-error", message: String(err && err.message || err),
+           detail: String(err && (err.stack || err.message) || err) });
   }
 }
 
@@ -531,7 +543,7 @@ json.dumps(_r)
     }
     post({ type: "done", result: payload }, transfers);
   } catch (err) {
-    post({ type: "log", line: "Internal error: " + String(err && err.message || err) });
+    post({ type: "log", line: "Internal error: " + String(err && (err.stack || err.message) || err) });
     post({ type: "done", result: { success: false, exitCode: -1, files: [] } });
   }
 }
@@ -873,7 +885,7 @@ wireDrop("dropBroker", "fileBroker", (files) => {
 
 /* ========================= engine / worker ============================= */
 let worker = null;
-function setEngine(cls, label, detail, pct) {
+function setEngine(cls, label, detail, pct, errorDetail) {
   state.engine = cls;
   const pill = $("enginePill");
   pill.className = "pill " + (cls === "ready" ? "ready" : cls === "error" ? "error" : "loading");
@@ -882,8 +894,23 @@ function setEngine(cls, label, detail, pct) {
   $("engineDetail").textContent = detail || "";
   if (pct != null) $("engineProgress").value = pct;
   $("engineProgress").style.display = cls === "loading" ? "" : "none";
+  const toggle = $("engineDetailToggle"), box = $("engineErrorBox");
+  if (cls === "error" && errorDetail) {
+    box.textContent = errorDetail;
+    toggle.style.display = "";
+  } else {
+    box.style.display = "none";
+    toggle.style.display = "none";
+    toggle.textContent = "Show details";
+  }
   refreshRunButton();
 }
+$("engineDetailToggle").onclick = () => {
+  const box = $("engineErrorBox");
+  const show = box.style.display === "none";
+  box.style.display = show ? "" : "none";
+  $("engineDetailToggle").textContent = show ? "Hide details" : "Show details";
+};
 function startEngine() {
   if (worker || !BUNDLE) return;
   const src = document.getElementById("osa-worker-src").textContent;
@@ -896,7 +923,8 @@ function startEngine() {
       $("verInfo").textContent = "v" + msg.version;
     }
     else if (msg.type === "init-error")
-      setEngine("error", "Engine failed", msg.message + " — check your internet connection and reload.");
+      setEngine("error", "Engine failed", msg.message + " — check your internet connection and reload.",
+                null, msg.detail || msg.message);
     else if (msg.type === "log") {
       state.lastLog.push(msg.line);
       const log = $("runLog");
@@ -905,7 +933,8 @@ function startEngine() {
     }
     else if (msg.type === "done") onRunDone(msg.result);
   };
-  worker.onerror = (e) => setEngine("error", "Engine failed", e.message || "Worker error");
+  worker.onerror = (e) => setEngine("error", "Engine failed", e.message || "Worker error", null,
+    [e.message || "Worker error", e.filename ? "at " + e.filename + ":" + e.lineno : ""].filter(Boolean).join("\n"));
   const params = new URLSearchParams(location.search);
   const base = params.get("pyodide") || settings.pyodideBase || DEFAULT_PYODIDE_BASE;
   const indexURL = base.endsWith("/") ? base : base + "/";

--- a/web/dev/e2e_smoke.mjs
+++ b/web/dev/e2e_smoke.mjs
@@ -1,0 +1,135 @@
+/*
+ * Browser smoke test for the standalone web app.
+ *
+ * Drives the whole wizard in headless Chromium against the *mock* Pyodide
+ * runtime (web/dev/mock_pyodide.js), so it verifies the UI flow, the worker
+ * protocol, file plumbing, settings persistence and download generation —
+ * everything except Pyodide itself.  The Python pipeline is covered natively
+ * by pytest (tests/util/test_web_runner.py).
+ *
+ * Usage (requires Node + playwright with a Chromium install):
+ *   python scripts/build_web_app.py --output dist/web/opensteuerauszug.html
+ *   node web/dev/e2e_smoke.mjs dist/web/opensteuerauszug.html
+ */
+import http from "node:http";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
+
+// Resolve playwright from the local project, NODE_PATH, or a global install.
+const require = createRequire(import.meta.url);
+const { chromium } = (() => {
+  const candidates = ["playwright", process.env.PLAYWRIGHT_MODULE].filter(Boolean);
+  for (const candidate of candidates) {
+    try { return require(candidate); } catch (e) { /* try next */ }
+  }
+  throw new Error("playwright not found — `npm install playwright` or set PLAYWRIGHT_MODULE");
+})();
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "..", "..");
+const appHtml = path.resolve(process.argv[2] || "dist/web/opensteuerauszug.html");
+
+const SAMPLE_BROKER = path.join(repoRoot, "tests/samples/import/ibkr/vtandchill_2025.xml");
+const SAMPLE_KURSLISTE = path.join(repoRoot, "tests/samples/kursliste/kursliste_mini_2025.xml");
+
+function fail(msg) {
+  console.error("FAIL: " + msg);
+  process.exit(1);
+}
+function ok(msg) {
+  console.log("ok - " + msg);
+}
+
+// -- tiny static server ------------------------------------------------------
+const routes = {
+  "/app.html": { file: appHtml, type: "text/html; charset=utf-8" },
+  "/mock/pyodide.js": { file: path.join(here, "mock_pyodide.js"), type: "text/javascript" },
+};
+const server = http.createServer(async (req, res) => {
+  const route = routes[req.url.split("?")[0]];
+  if (!route) { res.writeHead(404); res.end(); return; }
+  res.writeHead(200, { "content-type": route.type });
+  res.end(await readFile(route.file));
+});
+await new Promise((r) => server.listen(0, "127.0.0.1", r));
+const base = `http://127.0.0.1:${server.address().port}`;
+const url = `${base}/app.html?pyodide=${encodeURIComponent(base + "/mock/")}`;
+
+const browser = await chromium.launch();
+try {
+  const page = await browser.newPage();
+  page.on("pageerror", (err) => fail("page error: " + err));
+  await page.goto(url);
+
+  // Step 1: disclaimer must gate the wizard.
+  if (!(await page.locator("#btnStart").isDisabled())) fail("start not gated on disclaimer");
+  await page.check("#ack");
+  await page.click("#btnStart");
+  ok("disclaimer gate");
+
+  // Step 2: settings.
+  await page.fill("#fullName", "Maxine Muster");
+  await page.selectOption("#canton", "ZH");
+  await page.fill("#taxYear", "2025");
+  await page.selectOption("#importer", "ibkr");
+  await page.locator("#fullName").blur();
+  const toml = await page.inputValue("#tomlText");
+  if (!toml.includes('full_name = "Maxine Muster"')) fail("generated TOML missing name:\n" + toml);
+  ok("settings form generates config.toml");
+  await page.click('section[data-step="1"] [data-nav="next"]');
+
+  // Step 3: kursliste upload.
+  await page.setInputFiles("#fileKursliste", SAMPLE_KURSLISTE);
+  await page.waitForSelector("#listKursliste li");
+  ok("kursliste added");
+  await page.click('section[data-step="2"] [data-nav="next"]');
+
+  // Step 4: broker file upload.
+  await page.setInputFiles("#fileBroker", SAMPLE_BROKER);
+  await page.waitForSelector("#listBroker li");
+  ok("broker file added");
+  await page.click('section[data-step="3"] [data-nav="next"]');
+
+  // Step 5: wait for the (mock) engine, then run.
+  await page.waitForSelector("#enginePill.ready", { timeout: 30000 });
+  ok("engine ready");
+  await page.waitForSelector("#btnRun:not([disabled])");
+  await page.click("#btnRun");
+
+  // Step 6: results.
+  await page.waitForSelector('section[data-step="5"].active', { timeout: 30000 });
+  const links = page.locator("#downloads a.dlbtn");
+  if ((await links.count()) !== 2) fail("expected 2 download links");
+  const pdfName = await links.first().getAttribute("download");
+  if (pdfName !== "steuerauszug_2025.pdf") fail("bad pdf download name: " + pdfName);
+  const log = await page.textContent("#resultLog");
+  if (!log.includes("MOCK inputs: vtandchill_2025.xml")) fail("broker file did not reach engine:\n" + log);
+  if (!log.includes("MOCK kursliste: kursliste_mini_2025.xml")) fail("kursliste did not reach engine:\n" + log);
+  if (!log.includes('full_name = "Maxine Muster"')) fail("config did not reach engine:\n" + log);
+  ok("pipeline received files + config, downloads offered");
+
+  // Download really contains the produced bytes.
+  const [download] = await Promise.all([page.waitForEvent("download"), links.first().click()]);
+  const stream = await download.createReadStream();
+  const chunks = [];
+  for await (const c of stream) chunks.push(c);
+  if (!Buffer.concat(chunks).toString().startsWith("%PDF")) fail("downloaded PDF has wrong content");
+  ok("PDF download contains engine output");
+
+  // Persistence: settings (localStorage) and kursliste (IndexedDB) survive reload.
+  await page.reload();
+  await page.waitForSelector("#enginePill");
+  if ((await page.inputValue("#fullName")) !== "Maxine Muster") fail("settings not persisted");
+  // The list lives in a not-yet-visible step section, so wait for attachment.
+  await page.waitForSelector("#listKursliste li", { state: "attached", timeout: 10000 });
+  const cached = await page.locator("#listKursliste li .meta").textContent();
+  if (!cached.includes("cached")) fail("kursliste not restored from IndexedDB");
+  ok("settings + kursliste persist across reload");
+
+  console.log("\nAll web app smoke tests passed.");
+} finally {
+  await browser.close();
+  server.close();
+}

--- a/web/dev/e2e_smoke.mjs
+++ b/web/dev/e2e_smoke.mjs
@@ -106,9 +106,18 @@ try {
   if (pdfName !== "steuerauszug_2025.pdf") fail("bad pdf download name: " + pdfName);
   const log = await page.textContent("#resultLog");
   if (!log.includes("MOCK inputs: vtandchill_2025.xml")) fail("broker file did not reach engine:\n" + log);
-  if (!log.includes("MOCK kursliste: kursliste_mini_2025.xml")) fail("kursliste did not reach engine:\n" + log);
+  if (!log.includes("MOCK converted kursliste_mini_2025.xml -> kursliste_2025.sqlite"))
+    fail("kursliste XML was not converted:\n" + log);
+  if (!log.includes("MOCK kursliste: kursliste_2025.sqlite"))
+    fail("pipeline did not receive the converted kursliste:\n" + log);
   if (!log.includes('full_name = "Maxine Muster"')) fail("config did not reach engine:\n" + log);
   ok("pipeline received files + config, downloads offered");
+
+  // The converted sqlite must replace the XML in the kursliste list (and cache).
+  const klName = await page.locator("#listKursliste li .name").textContent();
+  if (!klName.includes("kursliste_2025.sqlite"))
+    fail("converted sqlite did not replace the XML in the list: " + klName);
+  ok("converted kursliste replaces the XML");
 
   // Download really contains the produced bytes.
   const [download] = await Promise.all([page.waitForEvent("download"), links.first().click()]);
@@ -126,7 +135,10 @@ try {
   await page.waitForSelector("#listKursliste li", { state: "attached", timeout: 10000 });
   const cached = await page.locator("#listKursliste li .meta").textContent();
   if (!cached.includes("cached")) fail("kursliste not restored from IndexedDB");
-  ok("settings + kursliste persist across reload");
+  const cachedName = await page.locator("#listKursliste li .name").textContent();
+  if (!cachedName.includes("kursliste_2025.sqlite"))
+    fail("cache should hold the converted sqlite, got: " + cachedName);
+  ok("settings + converted kursliste persist across reload");
 
   console.log("\nAll web app smoke tests passed.");
 } finally {

--- a/web/dev/mock_pyodide.js
+++ b/web/dev/mock_pyodide.js
@@ -1,0 +1,112 @@
+/*
+ * Mock Pyodide runtime for testing the web app UI without downloading the
+ * real (~40 MB) WebAssembly runtime.
+ *
+ * Implements just enough of the Pyodide API surface used by the worker in
+ * web/app_template.html: loadPyodide, FS, loadPackage, pyimport("micropip"),
+ * globals and runPython/runPythonAsync.  The "pipeline run" verifies that
+ * the expected files were written into the virtual filesystem and produces
+ * dummy PDF/XML outputs, so an end-to-end browser test can drive the whole
+ * wizard.  Used by web/dev/e2e_smoke.mjs.
+ */
+"use strict";
+
+function makeFS() {
+  const files = new Map(); // path -> Uint8Array
+  const dirs = new Set(["/"]);
+  const DIR_MODE = 0x4000;
+  const FILE_MODE = 0x8000;
+  const parent = (p) => p.slice(0, p.lastIndexOf("/")) || "/";
+  return {
+    mkdirTree(path) {
+      const parts = path.split("/").filter(Boolean);
+      let cur = "";
+      for (const part of parts) {
+        cur += "/" + part;
+        dirs.add(cur);
+      }
+    },
+    writeFile(path, data) {
+      this.mkdirTree(parent(path));
+      files.set(path, typeof data === "string" ? new TextEncoder().encode(data) : data);
+    },
+    readFile(path) {
+      if (!files.has(path)) throw new Error("mock FS: no such file " + path);
+      return files.get(path);
+    },
+    readdir(path) {
+      const names = new Set([".", ".."]);
+      const prefix = path === "/" ? "/" : path + "/";
+      for (const p of [...files.keys(), ...dirs]) {
+        if (p !== path && p.startsWith(prefix)) {
+          names.add(p.slice(prefix.length).split("/")[0]);
+        }
+      }
+      return [...names];
+    },
+    stat(path) {
+      if (dirs.has(path)) return { mode: DIR_MODE };
+      if (files.has(path)) return { mode: FILE_MODE };
+      throw new Error("mock FS: no such path " + path);
+    },
+    isDir(mode) { return mode === DIR_MODE; },
+    unlink(path) { files.delete(path); },
+    rmdir(path) { dirs.delete(path); },
+    _files: files,
+  };
+}
+
+function loadPyodide(_opts) {
+  const FS = makeFS();
+  const globals = new Map();
+  const pyodide = {
+    FS,
+    globals: { set: (k, v) => globals.set(k, v), get: (k) => globals.get(k) },
+    async loadPackage(_names, _opts2) {},
+    pyimport(name) {
+      if (name === "micropip") {
+        return { install: { async callKwargs(_reqs, _kw) {} } };
+      }
+      throw new Error("mock pyimport: " + name);
+    },
+    runPython(code) {
+      if (code.includes("ensure_workspace")) {
+        for (const d of ["input", "kursliste", "output", "config"]) FS.mkdirTree("/work/" + d);
+        globals.set("_version", "0.0-mock");
+      }
+    },
+    async runPythonAsync(code) {
+      if (!code.includes("run_process")) throw new Error("mock: unexpected python\n" + code);
+      const params = JSON.parse(globals.get("_params_json"));
+      const log = globals.get("_log_cb");
+      log("MOCK pipeline starting");
+      log("MOCK importer=" + params.importer + " tax_year=" + params.tax_year);
+      const inputs = FS.readdir("/work/input").filter((n) => n !== "." && n !== "..");
+      const kursliste = FS.readdir(params.kursliste_dir).filter((n) => n !== "." && n !== "..");
+      log("MOCK inputs: " + inputs.join(", "));
+      log("MOCK kursliste: " + kursliste.join(", "));
+      log("MOCK config:\n" + new TextDecoder().decode(FS.readFile(params.config_path)));
+      const outputs = {};
+      let exitCode = 0;
+      if (!inputs.length || !kursliste.length) {
+        log("MOCK error: missing input or kursliste files");
+        exitCode = 1;
+      } else {
+        FS.writeFile(params.output_pdf, "%PDF-1.4 mock steuerauszug\n%%EOF");
+        FS.writeFile(params.xml_output, "<taxStatement mock='true'/>");
+        outputs.pdf = params.output_pdf;
+        outputs.xml = params.xml_output;
+        log("Processing finished successfully.");
+      }
+      return JSON.stringify({
+        exit_code: exitCode,
+        success: exitCode === 0,
+        outputs,
+      });
+    },
+  };
+  return Promise.resolve(pyodide);
+}
+
+// importScripts() target: expose the entry point like the real pyodide.js.
+self.loadPyodide = loadPyodide;

--- a/web/dev/mock_pyodide.js
+++ b/web/dev/mock_pyodide.js
@@ -76,6 +76,23 @@ function loadPyodide(_opts) {
       }
     },
     async runPythonAsync(code) {
+      if (code.includes("convert_kursliste_xmls")) {
+        // Emulate the streaming XML -> SQLite conversion: replace each XML in
+        // /work/kursliste with a mock kursliste_<year>.sqlite.
+        const log = globals.get("_log_cb");
+        const result = { converted: [], skipped: [], errors: [] };
+        for (const name of FS.readdir("/work/kursliste")) {
+          if (!/\.xml$/i.test(name)) continue;
+          const year = (name.match(/(\d{4})/) || [])[1] || "0000";
+          const dbPath = "/work/kursliste/kursliste_" + year + ".sqlite";
+          FS.writeFile(dbPath, "SQLite mock (from " + name + ")");
+          FS.unlink("/work/kursliste/" + name);
+          log("MOCK converted " + name + " -> kursliste_" + year + ".sqlite");
+          result.converted.push({ source: name, path: dbPath, year: Number(year),
+                                  size: FS.readFile(dbPath).length });
+        }
+        return JSON.stringify(result);
+      }
       if (!code.includes("run_process")) throw new Error("mock: unexpected python\n" + code);
       const params = JSON.parse(globals.get("_params_json"));
       const log = globals.get("_log_cb");


### PR DESCRIPTION
Implements the user guide's "See if this can be deployed as a standalone web page with WASM" next step: a **downloadable single HTML file** (`opensteuerauszug.html`) that runs the complete import → calculate → reconcile → render pipeline client-side via [Pyodide](https://pyodide.org), wrapped in a step-by-step wizard UI.

## What the user gets

Open the file in a browser and a six-step wizard guides you through:

1. **Welcome** — disclaimer gate; the Python engine loads in the background with a progress bar.
2. **Your details** — name, canton, tax year, language, broker, calculation level, account numbers (Schwab/Fidelity). Translated into `config.toml` (viewable/hand-editable under *Advanced*). **Persisted in localStorage** and prefilled next time.
3. **Kursliste** — drag-and-drop `kursliste_YYYY.xml`/`.sqlite`, with a link to ictax.admin.ch and guidance. **Cached in IndexedDB**, so it's added once per tax year; warns when no file matches the chosen year.
4. **Broker files** — importer-specific instructions and file pickers (single Flex XML for IBKR, multi-file for Schwab/Fidelity/DEGIRO), optional pre/post-amble PDFs.
5. **Generate** — pre-flight validation with actionable blockers, then the pipeline runs in a web worker with the processing log streamed live.
6. **Download** — PDF + eCH-0196 XML download buttons, surfaced warnings from the log, and the verification checklist from the user guide.

Privacy: broker data never leaves the machine; the only network traffic is the Pyodide runtime (jsDelivr) and PyPI wheels, both cacheable/self-hostable (`?pyodide=` override or the Advanced option on the welcome step).

## How it works

- **`web/app_template.html`** — the whole UI in plain HTML/CSS/JS (no build tooling, light/dark theme). Pyodide runs in a Blob-URL web worker so the UI stays responsive; files travel to/from the worker as transferable ArrayBuffers.
- **`src/opensteuerauszug/util/web_runner.py`** — small bridge that invokes the existing Typer `process` command programmatically, streams stdout/stderr/log lines via callback, and reports produced outputs. No Pyodide imports, so it's covered by the normal pytest suite.
- **`scripts/build_web_app.py`** — builds a wheel of this repo plus the git-pinned deps (`ibflex2`, `pdf417gen`, which micropip can't fetch), embeds them base64 in the template together with the default `security_identifiers.csv`, and records the PyPI dependency list installed at page load via micropip (binary deps `lxml`/`Pillow`/`pydantic_core` come prebuilt from the Pyodide 0.29.4 distribution — availability of every dependency was verified against the Pyodide lockfile / PyPI pure wheels).
- **`web/dev/`** — a mock Pyodide runtime + Playwright smoke test that drives the entire wizard in headless Chromium.
- **`.github/workflows/web-app.yml`** — builds the HTML, runs the browser smoke test, and uploads `opensteuerauszug.html` as a workflow artifact (linked from `docs/webapp.md`).

## Testing

- `tests/util/test_web_runner.py` — runs the real pipeline through the web entry point (IBKR vtandchill sample + mini Kursliste → PDF/XML), failure reporting without a Kursliste, and repeat-run log-handler hygiene (the browser reuses one interpreter).
- `tests/scripts/test_build_web_app.py` — dependency splitting, wheel/CSV embedding, and that the injected JSON can never break out of its `<script>` block.
- `web/dev/e2e_smoke.mjs` — headless Chromium, full wizard: disclaimer gate, TOML generation, uploads reaching the engine's virtual FS, download contents, and settings/Kursliste persistence across reload. All green locally; full suite: **866 passed, 7 skipped**; black/flake8/pyrefly clean.

Not verified here (container network policy blocks the Pyodide CDN): a run against the real WASM runtime — worth one manual open-in-browser check of the CI artifact.

## Limitations

- Large Kursliste XML parsing in the browser is slow; the UI recommends the SQLite form (`opensteuerauszug kursliste download`).
- `verify` mode and the Kursliste downloader are not exposed in the UI (CORS would block direct ESTV download anyway).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T7D4J8EzRuBkujB5NmngBc