### PR TITLE
docs(web): make standalone web app docs more end-user friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This goal is to eliminate tedious and error prone manual typing into the tax sof
 - the main focus is on getting core transaction and interest data.
 - These need to be verified by the user before submitting with the tax return
 - Tax values are computed best effort for informational purpose (the main Tax software should be able to compute it from the core transaction data.
+- The [standalone web app](docs/webapp.md)'s browser wizard is a separate, mostly AI-coded UI layer and has seen much less real-world testing than the Python/CLI version. Prefer the CLI if you can install it.
 
 For more information on required due diligence see the the user guide.
 
@@ -176,6 +177,10 @@ This project includes utility scripts for development and data management. For d
 This project exists in part for me to try out AI based coding outside of $WORKPLACE to try out various tools. As a result code quality and style is inconsistent and contains various AIisms. Code has been cleaned-up, reviewed and controlled by me where it matters.
 
 That said all mistakes, hallucinations etc are probably mine.
+
+The [standalone web app](docs/webapp.md) is a particularly heavy case: the browser-side
+wizard (`web/app_template.html` and its JS) is mostly AI-generated and has had far less
+real-world exercise than the core library and CLI. Treat it as more experimental.
 
 ## Related projects
 

--- a/README.md
+++ b/README.md
@@ -14,14 +14,6 @@ For more information on required due diligence see the the user guide.
 
 ## Usage
 
-### Standalone web app (no installation)
-
-OpenSteuerAuszug also ships as a **single HTML file** that runs the whole
-pipeline in your browser via WebAssembly — download it, open it, and a
-wizard guides you through the steps. Your financial data never leaves your
-computer. See the [web app guide](docs/webapp.md) for where to get it and
-how it works, or build it yourself with `python scripts/build_web_app.py`.
-
 ### Main usage case: Generating Steuerauszug from Broker Data
 
 After installing, use the [User Guide](docs/user_guide.md) as the main
@@ -76,6 +68,13 @@ Agentic browsers are getting very close just be able to do the above all by them
 The [EWV](https://www.ewv-ete.ch/de/ewv-ete/) and SSK publish a [shared set of tools](https://forum.mustachianpost.com/t/programmatic-tax-return/11908/69) that is even referenced in the spec. This used to available online, but is now locked down to a cabal of banks and tax officials. Inquiring minds however have noticed that the JAR is [included in nearly every offline official Tax software](https://mkiesel.ch/posts/swiss-tax-adventures-1/). It includes an official sample renderer for the PDF version given an XML file, so you could also use that instead of the python renderer. It will look a bit more official. I wasn't aware this existed and had to reconstruct from scratch as well as fix a lot of the python PDF417 libraries. The spec refers to the library as open source but non of these actually include the source.
 
 ## Installation
+
+### Standalone web app (no installation)
+
+OpenSteuerAuszug also ships as a **single HTML file** that runs the whole
+pipeline in your browser — download it, open it, and a wizard guides you
+through the steps. Your financial data never leaves your computer. See the
+[web app guide](docs/webapp.md) for where to get it and how it works.
 
 ### Quick install (recommended for users)
 

--- a/docs/technical_notes.md
+++ b/docs/technical_notes.md
@@ -53,3 +53,60 @@ The software tries to delegate tax decisions to the Kursliste or avoid making th
 
 All of these will likely have negligible effect on the actual tax due. 
 
+## Standalone web app
+
+Implementation details for the [standalone web app](webapp.md), which runs
+the pipeline in the browser via WebAssembly (compiled with
+[Pyodide](https://pyodide.org)).
+
+### Network requests
+
+The page makes exactly two kinds of network requests, both for public
+open-source code:
+
+1. The Pyodide Python runtime from the jsDelivr CDN (~15 MB, once, then
+   cached by the browser).
+2. The Python library dependencies from PyPI (cached likewise).
+
+The OpenSteuerAuszug code itself is embedded inside the HTML file. Settings
+are stored in the browser's local storage, and the Kursliste file is cached
+in IndexedDB.
+
+### Building it yourself
+
+```bash
+python scripts/build_web_app.py            # writes dist/web/opensteuerauszug.html
+```
+
+The script builds a wheel of this repository plus the git-pinned
+dependencies (`ibflex2`, `pdf417gen`), embeds them base64-encoded into
+`web/app_template.html`, and records the PyPI dependency list which the page
+installs at load time via micropip (binary packages such as `lxml` and
+`Pillow` come prebuilt from the Pyodide distribution). Building requires
+network access to PyPI and GitHub.
+
+### Self-hosting / offline Pyodide
+
+By default the page loads Pyodide from jsDelivr. To use a self-hosted copy,
+either open the page with `?pyodide=https://your.host/pyodide/v0.29.4/full/`
+or set the base URL under *Advanced: runtime options* on the welcome step.
+
+### Development notes
+
+- The UI lives in `web/app_template.html` (plain HTML/CSS/JS, no build
+  tooling). The Python side entry point is
+  `src/opensteuerauszug/util/web_runner.py`, which is covered by the normal
+  pytest suite (`tests/util/test_web_runner.py`).
+- `web/dev/e2e_smoke.mjs` drives the whole wizard in headless Chromium
+  against a mock Pyodide runtime (`web/dev/mock_pyodide.js`):
+
+  ```bash
+  python scripts/build_web_app.py
+  npm install playwright && npx playwright install chromium
+  node web/dev/e2e_smoke.mjs dist/web/opensteuerauszug.html
+  ```
+
+- CI builds and smoke-tests the app via `.github/workflows/web-app.yml` and
+  uploads the HTML as an artifact.
+
+

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -32,6 +32,11 @@ If you prefer not to install the tool, `uv run --with git+https://github.com/vro
 also works for one-off commands.
 
 You can replace `ibkr` with `schwab`, `fidelity`, or `degiro` depending on your source data.
+
+Prefer not to install anything? Download the standalone web app (a single
+HTML file that runs entirely in your browser) and follow the on-screen
+wizard instead — see the [web app guide](webapp.md).
+
 The rest of this guide explains each step in detail.
 
 ## Short Primer on Tax data and calculations

--- a/docs/webapp.md
+++ b/docs/webapp.md
@@ -1,38 +1,29 @@
 # Standalone Web App
 
 OpenSteuerAuszug can run as a **single HTML file in your browser** — no
-Python installation needed. The page embeds the full processing pipeline
-(compiled to WebAssembly via [Pyodide](https://pyodide.org)) and walks you
-through generating your Steuerauszug step by step.
+Python installation needed. The page contains the full processing pipeline
+and walks you through generating your Steuerauszug step by step.
 
 ## Privacy model
 
 Your broker statements, personal details and the generated Steuerauszug
-**never leave your computer**. The page makes exactly two kinds of network
-requests, both for public open-source code:
-
-1. The Pyodide Python runtime from the jsDelivr CDN (~15 MB, once, then
-   cached by the browser).
-2. The Python library dependencies from PyPI (cached likewise).
-
-The OpenSteuerAuszug code itself is embedded inside the HTML file. Settings
-are stored in the browser's local storage, and the (public, non-personal)
-Kursliste file is cached in IndexedDB so you only add it once per tax year.
+**never leave your computer**. Everything runs locally in the page. The only
+network traffic is fetching the (public, open-source) code the page needs to
+run, the first time you open it — after that it's cached by your browser.
 
 ## Getting the app
 
 Download `opensteuerauszug.html` from the *Web app* workflow artifact on the
-[GitHub Actions page](https://github.com/vroonhof/opensteuerauszug/actions/workflows/web-app.yml)
-(or build it yourself, see below), save it anywhere, and open it in a modern
-browser (Chrome/Edge/Firefox; an internet connection is needed on first load
-to fetch the runtime).
+[GitHub Actions page](https://github.com/vroonhof/opensteuerauszug/actions/workflows/web-app.yml),
+save it anywhere, and open it in a modern browser (Chrome/Edge/Firefox; an
+internet connection is needed on first load).
 
 ## Using the wizard
 
 The page guides you through six steps:
 
-1. **Welcome** — read the disclaimer; the Python engine starts loading in
-   the background (progress in the bar at the bottom).
+1. **Welcome** — read the disclaimer; the engine starts loading in the
+   background (progress in the bar at the bottom).
 2. **Your details** — name, canton, tax year, document language, broker and
    calculation level. Schwab and Fidelity additionally need your account
    number(s). Everything is remembered on this device. Under *Advanced* you
@@ -41,7 +32,8 @@ The page guides you through six steps:
 3. **Kursliste** — add the official ESTV Kursliste for your tax year
    (`kursliste_YYYY.xml` from [ictax.admin.ch](https://www.ictax.admin.ch/extern/en.html#/xml),
    or the much faster `kursliste_YYYY.sqlite` produced by
-   `opensteuerauszug kursliste download`). The file is cached in the browser.
+   `opensteuerauszug kursliste download`). The file is cached in the browser
+   so you only add it once per tax year.
 4. **Broker files** — add your broker export(s); the required files per
    broker are described in the importer guides (see the
    [user guide](user_guide.md)). Optionally attach PDFs to prepend/append.
@@ -53,47 +45,18 @@ The page guides you through six steps:
 All the caveats of the CLI apply unchanged — **verify the generated
 statement before filing** (see the [user guide](user_guide.md)).
 
-## Limitations compared to the CLI
+## Trade-offs compared to the CLI
 
+- **You have to fetch the Kursliste yourself.** The CLI's
+  `opensteuerauszug kursliste download` command talks directly to the ESTV
+  API; a web page can't do that due to standard browser security
+  restrictions (CORS). Download the Kursliste manually from
+  [ictax.admin.ch](https://www.ictax.admin.ch/extern/en.html#/xml) and add
+  it in the Kursliste step instead.
 - Processing a large Kursliste **XML** in the browser is slow (minutes) and
   memory-hungry; prefer the SQLite form for regular use.
-- The `verify` workflow for existing statements and the Kursliste download
-  command are not exposed in the UI.
+- The `verify` workflow for existing statements is not exposed in the UI.
 - Very large portfolios may hit browser memory limits.
 
-## Building it yourself
-
-```bash
-python scripts/build_web_app.py            # writes dist/web/opensteuerauszug.html
-```
-
-The script builds a wheel of this repository plus the git-pinned
-dependencies (`ibflex2`, `pdf417gen`), embeds them base64-encoded into
-`web/app_template.html`, and records the PyPI dependency list which the page
-installs at load time via micropip (binary packages such as `lxml` and
-`Pillow` come prebuilt from the Pyodide distribution). Building requires
-network access to PyPI and GitHub.
-
-### Self-hosting / offline Pyodide
-
-By default the page loads Pyodide from jsDelivr. To use a self-hosted copy,
-either open the page with `?pyodide=https://your.host/pyodide/v0.29.4/full/`
-or set the base URL under *Advanced: runtime options* on the welcome step.
-
-## Development notes
-
-- The UI lives in `web/app_template.html` (plain HTML/CSS/JS, no build
-  tooling). The Python side entry point is
-  `src/opensteuerauszug/util/web_runner.py`, which is covered by the normal
-  pytest suite (`tests/util/test_web_runner.py`).
-- `web/dev/e2e_smoke.mjs` drives the whole wizard in headless Chromium
-  against a mock Pyodide runtime (`web/dev/mock_pyodide.js`):
-
-  ```bash
-  python scripts/build_web_app.py
-  npm install playwright && npx playwright install chromium
-  node web/dev/e2e_smoke.mjs dist/web/opensteuerauszug.html
-  ```
-
-- CI builds and smoke-tests the app via `.github/workflows/web-app.yml` and
-  uploads the HTML as an artifact.
+For build instructions, self-hosting options, and other implementation
+details, see the [Technical Notes](technical_notes.md#standalone-web-app).

--- a/docs/webapp.md
+++ b/docs/webapp.md
@@ -4,6 +4,11 @@ OpenSteuerAuszug can run as a **single HTML file in your browser** — no
 Python installation needed. The page contains the full processing pipeline
 and walks you through generating your Steuerauszug step by step.
 
+> **Note:** the browser wizard itself (the UI around the same underlying
+> pipeline as the CLI) is mostly AI-coded and has seen much less real-world
+> testing. If you're comfortable installing the CLI, prefer that; use the
+> web app for convenience, but double-check its output carefully.
+
 ## Privacy model
 
 Your broker statements, personal details and the generated Steuerauszug

--- a/web/app_template.html
+++ b/web/app_template.html
@@ -172,7 +172,9 @@
       <div class="notice">
         <b>Disclaimer.</b> This tool is not formally audited. Tax values are computed on a best-effort,
         informational basis. <b>You</b> are responsible for verifying every figure before submitting your
-        tax return, and for the contents of that return. See the
+        tax return, and for the contents of that return. This browser wizard is additionally mostly
+        AI-coded and has seen much less real-world testing than the Python/CLI version — prefer the CLI
+        if you can install it. See the
         <a href="https://github.com/vroonhof/opensteuerauszug/blob/main/docs/user_guide.md" target="_blank" rel="noopener">user guide</a>.
       </div>
       <label class="checkbox">


### PR DESCRIPTION
## Summary
- Move the standalone web app mention out of the README's top-level Usage section and into Installation, as an alternative install path
- Add a short pointer to the standalone web app in the user guide's Quick Start (download the HTML, follow the wizard)
- Trim `docs/webapp.md` down to end-user content only, and call out the trade-off that the Kursliste must be downloaded manually because of browser CORS restrictions
- Move implementation details (build script, self-hosting/offline Pyodide, dev/CI notes) from `docs/webapp.md` into `docs/technical_notes.md`

## Test plan
- [x] Reviewed rendered markdown links resolve correctly (README -> docs/webapp.md, user_guide.md -> webapp.md, webapp.md -> technical_notes.md#standalone-web-app)