### PR TITLE
Publish the standalone web app to GitHub Pages

### DIFF
--- a/.github/workflows/web-app.yml
+++ b/.github/workflows/web-app.yml
@@ -1,5 +1,6 @@
-# Builds the standalone single-file web app (Pyodide based) and uploads it
-# as a workflow artifact. See docs/webapp.md.
+# Builds the standalone single-file web app (Pyodide based), uploads it
+# as a workflow artifact and, on pushes to main, deploys it to GitHub
+# Pages. See docs/webapp.md.
 
 name: Web app
 
@@ -13,6 +14,7 @@ on:
       - "src/opensteuerauszug/util/web_runner.py"
       - "pyproject.toml"
       - ".github/workflows/web-app.yml"
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -44,3 +46,36 @@ jobs:
           name: opensteuerauszug-webapp
           path: dist/web/opensteuerauszug.html
           if-no-files-found: error
+
+  # Publish the app to GitHub Pages so users get a stable URL instead of
+  # digging through workflow artifacts. Runs only for the main branch.
+  deploy:
+    needs: build
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Download built app
+        uses: actions/download-artifact@v4
+        with:
+          name: opensteuerauszug-webapp
+          path: _site
+      - name: Serve the app at the site root
+        run: cp _site/opensteuerauszug.html _site/index.html
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+        with:
+          enablement: true
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -72,10 +72,11 @@ The [EWV](https://www.ewv-ete.ch/de/ewv-ete/) and SSK publish a [shared set of t
 
 ### Standalone web app (no installation)
 
-OpenSteuerAuszug also ships as a **single HTML file** that runs the whole
-pipeline in your browser — download it, open it, and a wizard guides you
-through the steps. Your financial data never leaves your computer. See the
-[web app guide](docs/webapp.md) for where to get it and how it works.
+OpenSteuerAuszug also runs as a **single HTML page in your browser** — open
+**<https://vroonhof.github.io/opensteuerauszug/>** and a wizard guides you
+through the steps (or save the page locally and open it from disk). Your
+financial data never leaves your computer. See the
+[web app guide](docs/webapp.md) for details.
 
 ### Quick install (recommended for users)
 

--- a/docs/technical_notes.md
+++ b/docs/technical_notes.md
@@ -106,7 +106,9 @@ or set the base URL under *Advanced: runtime options* on the welcome step.
   node web/dev/e2e_smoke.mjs dist/web/opensteuerauszug.html
   ```
 
-- CI builds and smoke-tests the app via `.github/workflows/web-app.yml` and
-  uploads the HTML as an artifact.
+- CI builds and smoke-tests the app via `.github/workflows/web-app.yml`,
+  uploads the HTML as an artifact and, on pushes to `main`, deploys it to
+  GitHub Pages at <https://vroonhof.github.io/opensteuerauszug/> (served
+  both as `index.html` and as a downloadable `opensteuerauszug.html`).
 
 

--- a/docs/webapp.md
+++ b/docs/webapp.md
@@ -18,10 +18,19 @@ run, the first time you open it — after that it's cached by your browser.
 
 ## Getting the app
 
-Download `opensteuerauszug.html` from the *Web app* workflow artifact on the
-[GitHub Actions page](https://github.com/vroonhof/opensteuerauszug/actions/workflows/web-app.yml),
-save it anywhere, and open it in a modern browser (Chrome/Edge/Firefox; an
-internet connection is needed on first load).
+Simply open **<https://vroonhof.github.io/opensteuerauszug/>** in a modern
+browser (Chrome/Edge/Firefox) — that's the app, always built from the latest
+`main` branch. Everything still runs locally in the page.
+
+If you prefer a local copy (e.g. for offline use), download
+[`opensteuerauszug.html`](https://vroonhof.github.io/opensteuerauszug/opensteuerauszug.html)
+from the same site (right-click → *Save link as…*), save it anywhere, and
+open it from disk. An internet connection is needed on first load either
+way.
+
+Unreleased builds from pull requests are available as *Web app* workflow
+artifacts on the
+[GitHub Actions page](https://github.com/vroonhof/opensteuerauszug/actions/workflows/web-app.yml).
 
 ## Using the wizard
 

--- a/web/app_template.html
+++ b/web/app_template.html
@@ -31,6 +31,17 @@
   header.app h1 { margin: 0 0 2px; font-size: 22px; }
   header.app h1 .flag { font-size: 18px; }
   header.app p { margin: 0; color: var(--muted); font-size: 14px; }
+  header.app .headrow {
+    display: flex; align-items: baseline; justify-content: space-between;
+    gap: 12px; flex-wrap: wrap;
+  }
+  a.docs-link {
+    font-size: 14px; font-weight: 600; white-space: nowrap;
+    color: var(--accent); text-decoration: none;
+    border: 1px solid var(--border); border-radius: 999px; padding: 5px 14px;
+    background: var(--panel);
+  }
+  a.docs-link:hover { text-decoration: underline; }
   main { max-width: 900px; margin: 0 auto; padding: 0 24px 96px; }
 
   /* Stepper */
@@ -150,7 +161,10 @@
 <body>
 
 <header class="app">
-  <h1><span class="flag">🇨🇭</span> OpenSteuerAuszug <span style="font-weight:400;color:var(--muted);font-size:15px">— in your browser</span></h1>
+  <div class="headrow">
+    <h1><span class="flag">🇨🇭</span> OpenSteuerAuszug <span style="font-weight:400;color:var(--muted);font-size:15px">— in your browser</span></h1>
+    <a class="docs-link" href="https://github.com/vroonhof/opensteuerauszug/blob/main/docs/webapp.md" target="_blank" rel="noopener">📖 Documentation</a>
+  </div>
   <p>Generate a Swiss eCH-0196 tax statement (Steuerauszug) from broker data. Everything runs locally in this page — your financial data never leaves your computer.</p>
 </header>
 
@@ -162,6 +176,11 @@
     <div class="card">
       <h2>Welcome</h2>
       <p class="lead">This wizard walks you through generating your Steuerauszug in five short steps.</p>
+      <p style="font-size:14px;margin:0 0 10px"><b>New here? Start with the documentation:</b>
+        the <a href="https://github.com/vroonhof/opensteuerauszug/blob/main/docs/webapp.md" target="_blank" rel="noopener"><b>web app guide</b></a>
+        explains each step below, and the
+        <a href="https://github.com/vroonhof/opensteuerauszug/blob/main/docs/user_guide.md" target="_blank" rel="noopener"><b>user guide</b></a>
+        covers the tax background, broker exports and how to verify the result.</p>
       <ul style="font-size:14px;margin:0 0 10px;padding-left:20px">
         <li><b>Your details</b> — name, canton, tax year and broker (remembered on this device).</li>
         <li><b>Kursliste</b> — the official ESTV securities list for your tax year.</li>


### PR DESCRIPTION
## Summary
- Add a `deploy` job to the *Web app* workflow that publishes the built `opensteuerauszug.html` to **GitHub Pages** on every push to `main` (plus `workflow_dispatch` for manual runs). The app is served at the site root (`index.html`) and also as a downloadable `opensteuerauszug.html`, so users no longer have to dig through Actions artifacts.
- Since users now land directly in the app, the page gets a persistent **📖 Documentation** link in the header (visible on every wizard step) and a prominent "New here? Start with the documentation" pointer to the web app guide and user guide on the welcome step.
- `docs/webapp.md` "Getting the app" now leads with the Pages URL (https://vroonhof.github.io/opensteuerauszug/), with the Actions artifact kept as the route to unreleased PR builds. README and `docs/technical_notes.md` updated to match.

## One-time setup
The deploy step uses `actions/configure-pages` with `enablement: true`, which should enable Pages automatically on first run. If it fails with a permissions error, enable it once manually under **Settings → Pages → Source: GitHub Actions**, then re-run the workflow (it now supports manual dispatch).

## Test plan
- [x] Workflow YAML parses; deploy job is gated to non-PR events on `refs/heads/main`
- [x] Built the app locally (`python scripts/build_web_app.py`) and ran the full headless-Chromium smoke suite (`web/dev/e2e_smoke.mjs`) — all 9 tests pass with the template changes
- [x] Screenshot-checked the welcome page: header docs link and welcome-step docs pointer render correctly
- [ ] After merge: verify the `github-pages` deployment succeeds and https://vroonhof.github.io/opensteuerauszug/ loads the wizard