### PR TITLE
Promote the DEGIRO importer out of experimental status

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,11 @@ For now the focus is on brokers / banks that the author has
 
 - Charles Schwab (main trading account and Equity Awards)
 - Interactive Brokers
-  
+
+Thanks to community contributions we also support
+
+- DEGIRO (contributed by [@manuelgr0](https://github.com/manuelgr0), with multilingual support by [@dalpozz](https://github.com/dalpozz) and [@VincentBlondeau](https://github.com/VincentBlondeau))
+
 Additionally we can recalculate and verify any existing steuerauszug (this is mostly to increase confidence in the software itself)
 
 ## Related work and alternatives
@@ -199,6 +203,8 @@ real-world exercise than the core library and CLI. Treat it as more experimental
 Many thanks to everyone who has tested this tool with their own data and contributed fixes and improvements.
 
 Special thanks to [@pet-zh](https://github.com/pet-zh), whose extensive real-world testing and numerous fixes have made the output significantly more polished and reliable.
+
+The DEGIRO importer is a community effort: contributed by [@manuelgr0](https://github.com/manuelgr0), with multilingual support by [@dalpozz](https://github.com/dalpozz) and improved French support plus test data by [@VincentBlondeau](https://github.com/VincentBlondeau).
 
 ## License
 

--- a/docs/importer_degiro.md
+++ b/docs/importer_degiro.md
@@ -2,7 +2,7 @@
 
 ## Disclaimer and User Responsibility
 
-**Important**: The DEGIRO Importer is **experimental** and may not handle all cases correctly.
+**Important**: The DEGIRO importer is newer and has seen less real-world use than the Schwab and IBKR importers. It is designed to fail safe: if your export contains a row it does not recognize (e.g. from an account language that is not yet covered), processing stops with an error instead of silently dropping data — please [report such rows as a bug](https://github.com/vroonhof/opensteuerauszug/issues) so support can be added.
 
 As stated in the [Disclaimer](user_guide.md#disclaimer-and-user-responsibility), it is crucial to understand your role:
 
@@ -64,15 +64,6 @@ Pass this directory path to the `process` command (see below).
 
 ## Configuration (`config.toml`)
 
-### Enable the Experimental Importer
-
-Because this importer is still experimental, you must explicitly enable it in your `config.toml`:
-
-```toml
-[general]
-experimental_importers = true
-```
-
 ### Account Settings (Optional)
 
 You can optionally configure your DEGIRO account to customise the depot identifier used in the generated Steuerauszug:
@@ -119,7 +110,16 @@ opensteuerauszug process path/to/degiro/ \
 *   **Dividend withholding tax**: `Dividend Tax` rows in `Account.csv` are automatically matched to their parent dividend and reported as `nonRecoverableTaxAmountOriginal` in the generated XML.
 *   **FX rows**: `FX Credit` / `FX Debit` rows that accompany a trade are consumed internally and do not generate separate output entries.
 *   **Cash balance**: The CHF cash balance is taken from the `CASH & CASH FUND` row in `Portfolio.csv`.
-*   **Testing**: This importer has been tested against real data for the 2023 tax year. Other years should work but may reveal edge cases.
+*   **Account language**: Row descriptions in `Account.csv` depend on your account language. English, Italian, French and German are supported; other languages will stop with an "Unknown DEGIRO row" error — please report these so support can be added.
+*   **Testing**: This importer has been tested against real data from multiple users and account languages. Unusual account histories may still reveal edge cases.
+
+## Credits
+
+The DEGIRO importer exists thanks to community contributions:
+
+*   [@manuelgr0](https://github.com/manuelgr0) — original importer implementation.
+*   [@dalpozz](https://github.com/dalpozz) — multilingual support (Italian, French, German).
+*   [@VincentBlondeau](https://github.com/VincentBlondeau) — improved French support and a complete anonymized test export.
 
 ---
 Return to [User Guide](user_guide.md)

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -229,7 +229,7 @@ Currently supported brokers and their specific guides:
 *   **[Charles Schwab](importer_schwab.md)**: For brokerage and equity award accounts.
 *   **[Interactive Brokers (IBKR)](importer_ibkr.md)**: For brokerage accounts.
 *   **[Fidelity Investments](importer_fidelity.md)**: For brokerage accounts.
-*   **[DEGIRO](importer_degiro.md)**: For brokerage accounts. *(experimental)*
+*   **[DEGIRO](importer_degiro.md)**: For brokerage accounts.
 
 Please refer to the documentation for your specific broker by clicking the links above to understand what files to download, their formats, and any specific configurations required in `config.toml`.
 

--- a/src/opensteuerauszug/steuerauszug.py
+++ b/src/opensteuerauszug/steuerauszug.py
@@ -323,7 +323,12 @@ def process(
 
     # --- Validation of Importer Type based on experimental flag ---
     if not experimental_importers_enabled:
-        if importer_type not in [ImporterType.SCHWAB, ImporterType.IBKR, ImporterType.NONE]:
+        if importer_type not in [
+            ImporterType.SCHWAB,
+            ImporterType.IBKR,
+            ImporterType.DEGIRO,
+            ImporterType.NONE,
+        ]:
             raise typer.BadParameter(
                 f"Importer '{importer_type.value}' is experimental and requires 'experimental_importers = true' in configuration (general section) to be used."
             )

--- a/web/app_template.html
+++ b/web/app_template.html
@@ -248,7 +248,7 @@
             <option value="ibkr">Interactive Brokers (Flex Query XML)</option>
             <option value="schwab">Charles Schwab (statement exports)</option>
             <option value="fidelity">Fidelity (experimental)</option>
-            <option value="degiro">DEGIRO (experimental)</option>
+            <option value="degiro">DEGIRO</option>
           </select>
         </label>
         <label class="field"><b>Tax value calculation</b>
@@ -652,7 +652,7 @@ function sanitizeAlias(s, i) {
 }
 
 /* ====================== configuration generation ====================== */
-const EXPERIMENTAL = { fidelity: true, degiro: true };
+const EXPERIMENTAL = { fidelity: true };
 const ACCOUNTS_REQUIRED = { schwab: true, fidelity: true };
 
 function generateToml() {
@@ -889,7 +889,7 @@ const BROKER_INFO = {
     accept: "", multiple: true,
   },
   degiro: {
-    lead: "DEGIRO (experimental): the account and transaction CSV exports for the tax year.",
+    lead: "DEGIRO: the Account.csv and Portfolio.csv exports for the tax year.",
     help: 'See the <a target="_blank" rel="noopener" ' +
       'href="https://github.com/vroonhof/opensteuerauszug/blob/main/docs/importer_degiro.md">DEGIRO guide</a> ' +
       "for the required exports, then add them all below.",


### PR DESCRIPTION
## Summary
- Remove `DEGIRO` from the `experimental_importers` config gate in `steuerauszug.py` — it can now be used without `experimental_importers = true`. The flag remains in place for Fidelity.
- Update `docs/importer_degiro.md`: drop the experimental-flag setup section, reframe the disclaimer around the importer's fail-safe design (unrecognized rows stop processing with an error rather than silently dropping data), document the supported account languages (EN/IT/FR/DE), and add a Credits section.
- Drop the *(experimental)* tag in `docs/user_guide.md` and list DEGIRO under Supported Brokers in the README.

## Why now
Following #415 the importer has real-world coverage from multiple users and locales, a complete anonymized end-to-end export as a test fixture, and 96 passing tests. Crucially it fails loudly on anything it does not recognize, so locale gaps surface as hard errors (and bug reports), not silent data loss.

## Credits
The DEGIRO importer is a community effort — now acknowledged in the README and importer guide:
- @manuelgr0 — original importer (#393)
- @dalpozz — multilingual IT/FR/DE support (#404)
- @VincentBlondeau — improved French support and complete test export (#415)

## Test plan
- [x] `pytest tests/importers/degiro/` — 96 passed
- [x] End-to-end CLI run on the French sample export (`process --importer degiro` with a minimal config, no experimental flag) renders a PDF successfully
- [x] Grepped that no stale "experimental DEGIRO" references remain in docs or code