### PR TITLE
fix: preserve all DEGIRO cash balances

### DIFF
--- a/src/opensteuerauszug/importers/degiro/degiro_importer.py
+++ b/src/opensteuerauszug/importers/degiro/degiro_importer.py
@@ -26,7 +26,7 @@ import re
 from collections import defaultdict
 from datetime import date, timedelta
 from decimal import Decimal
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 from opensteuerauszug.config.models import DegiroAccountSettings
 from opensteuerauszug.importers.common import (
@@ -139,8 +139,7 @@ class DegiroImporter:
         )
 
         # Step 1 – Seed closing balances from Portfolio.csv
-        cash_balance: Optional[Decimal] = None
-        cash_currency: str = "CHF"
+        cash_balances: List[tuple[Decimal, str]] = []
 
         end_plus_one = self.period_to + timedelta(days=1)
 
@@ -149,8 +148,7 @@ class DegiroImporter:
         isin_to_entry: Dict[str, PortfolioEntry] = {}
         for entry in portfolio_entries:
             if entry.is_cash:
-                cash_balance = entry.local_amount
-                cash_currency = entry.local_currency or "CHF"
+                cash_balances.append((entry.local_amount, entry.local_currency or "CHF"))
                 continue
             if not _valid_isin(entry.isin):
                 logger.debug("Skipping portfolio entry with non-ISIN: %s", entry.isin)
@@ -302,17 +300,19 @@ class DegiroImporter:
         )
 
         # Step 8 – Augment bank accounts
-        if cash_balance is not None:
-            cash_entry = CashAccountEntry(
+        cash_entries = [
+            CashAccountEntry(
                 account_id=self._depot_id,
-                currency=cash_currency,
-                closing_balance=cash_balance,
+                currency=currency,
+                closing_balance=balance,
                 payments=[],
                 country="NL",
-                name=f"{self._depot_id} {cash_currency}",
-                number=f"{self._depot_id}-{cash_currency}",
+                name=f"{self._depot_id} {currency}",
+                number=f"{self._depot_id}-{currency}",
             )
-            augment_list_of_bank_accounts(statement, [cash_entry])
+            for balance, currency in cash_balances
+        ]
+        augment_list_of_bank_accounts(statement, cash_entries)
 
         return statement
 

--- a/tests/importers/degiro/test_degiro_importer.py
+++ b/tests/importers/degiro/test_degiro_importer.py
@@ -8,6 +8,7 @@ EXTRA_SAMPLE_DIR/import/degiro/).  See design/testing.md for details.
 import os
 import re
 from datetime import date
+from decimal import Decimal
 
 import pytest
 
@@ -85,6 +86,39 @@ def test_import_dir_raises_on_missing_files(tmp_path):
     )
     with pytest.raises(FileNotFoundError):
         importer.import_dir(str(tmp_path))
+
+
+def test_import_files_preserves_cash_accounts_in_each_currency(tmp_path):
+    account_csv = tmp_path / "Account.csv"
+    account_csv.write_text(
+        "Date,Time,Value date,Product,ISIN,Description,FX,Change,,Balance,,Order Id\n",
+        encoding="utf-8",
+    )
+    portfolio_csv = tmp_path / "Portfolio.csv"
+    portfolio_csv.write_text(
+        "Product,Symbol/ISIN,Amount,Closing,Local value,,Value in CHF\n"
+        "CASH & CASH FUND & FTX CASH (CHF),,,,CHF,500.00,500.00\n"
+        "CASH & CASH FUND & FTX CASH (USD),,,,USD,200.00,180.00\n",
+        encoding="utf-8",
+    )
+    importer = DegiroImporter(
+        period_from=PERIOD_FROM,
+        period_to=PERIOD_TO,
+        account_settings_list=[],
+    )
+
+    statement = importer.import_files(str(account_csv), str(portfolio_csv))
+
+    assert statement.listOfBankAccounts is not None
+    accounts = statement.listOfBankAccounts.bankAccount
+    balances = {}
+    for account in accounts:
+        assert account.taxValue is not None
+        balances[account.bankAccountCurrency] = account.taxValue.balance
+    assert balances == {
+        "CHF": Decimal("500.00"),
+        "USD": Decimal("200.00"),
+    }
 
 
 # fmt: off


### PR DESCRIPTION
Fixes #396

DEGIRO portfolio imports previously retained only the final cash row, dropping balances in earlier currencies. This collects every cash row and emits a separate bank account for each currency.

Tested with the full DEGIRO importer suite (97 tests), including a new CHF/USD regression.
